### PR TITLE
Minor usability improvement in FireFTP

### DIFF
--- a/src/content/fireftp.xul
+++ b/src/content/fireftp.xul
@@ -263,6 +263,8 @@
       <toolbarbutton id="editMenuItem"  label="&edit.label;"           accesskey="&edit.access;"       oncommand="editSite()"/>
       <toolbarbutton id="abortbutton"   label="&abort.label;"          accesskey="&abort.access;"      oncommand="doAbort()"/>
       <toolbarspacer flex="1"/>
+          <toolbarbutton id="createAccountButtonLeftSide" label="&addaccount.label;" accesskey="&addaccount.access;"  oncommand="newSite()" />
+          <toolbarbutton id="quickMenuItem" label="&qc.label;" accesskey="&qc.access;" oncommand="quickConnect()" />
       <toolbarbutton id="logbutton"     label="&logtab.label;"         accesskey="&logbutton.access;"  oncommand="showLog()" type="checkbox" persist="checked"  autoCheck="false" />
       <toolbarbutton id="advmenu"       label="&advanced.label;"       accesskey="&advanced.access;"   popup="advancedpopup"/>
       <toolbarbutton id="helpbutton"    label="&help.label;"           accesskey="&helpbutton.access;"

--- a/src/content/js/etc/sessionsPasswords.js
+++ b/src/content/js/etc/sessionsPasswords.js
@@ -259,7 +259,7 @@ function onFolderChange(dontSelect, click) {
   if (!gSiteManager.length) {
     gAccountField.setAttribute("label", gStrbundle.getString("createAccount"));
   }
-
+/*
   gAccountField.appendItem(gStrbundle.getString("createAccount"), "");
   gAccountField.firstChild.lastChild.setAttribute("oncommand", "newSite()");
   gAccountField.appendItem(gStrbundle.getString("quickConnectMenu"), "");
@@ -269,7 +269,7 @@ function onFolderChange(dontSelect, click) {
   if (gSiteManager.length) {
     gAccountField.firstChild.appendChild(document.createElement("menuseparator"));
   }
-
+*/
   for (var x = 0; x < gSiteManager.length; ++x) {
     if (gSiteManager[x].folder == gFolderField.value || (!gSiteManager[x].folder && gFolderField.value == "")) {
       gAccountField.appendItem(gSiteManager[x].account, gSiteManager[x].account);

--- a/src/locale/en-US/fireftp.dtd
+++ b/src/locale/en-US/fireftp.dtd
@@ -3,6 +3,12 @@
 
 <!ENTITY accountlist.label    "(Choose an account)">
 
+<!ENTITY addaccount.label    "Add Account...">
+<!ENTITY addaccount.access	  "A">
+
+<!ENTITY qc.label            "QuickConnect...">
+<!ENTITY qc.access           "Q">
+
 <!ENTITY edit.label           "Edit">
 <!ENTITY abort.label          "Abort">
 


### PR DESCRIPTION
We love FireFTP here at Web-Op-- been using it for years.  When the menu gets a large number of hosts on it, we tend to want to navigate by typing in the first few characters of the host.  This works well, except for hosts that start with "C" or "Q", as they fire off the Create New Account and QuickConnect dialogues.  To solve this problem, I moved the Create New Account and QuickConnect commands to buttons on the far right of the toolbar, so you can happily type whatever you want in the host selection box without triggering unwanted dialogues.

It might make sense to turn this into a configurable option.
