### PR TITLE
Issue #95 - Reading remote file changes file time

### DIFF
--- a/src/content/js/etc/programs.js
+++ b/src/content/js/etc/programs.js
@@ -221,12 +221,8 @@ function remoteLaunchProgram(extensionIndex, programIndex, fileIndex) {
 
         let remoteFile = remoteTree.data[x];
 
-        var func = function() {
-          var subFunc = function() { launchProgram(extensionIndex, programIndex, tmpFile, remoteFile); };
-          setTimeout(subFunc, 0);                                                                     // let the queue finish up
-        };
-
-        gConnection.download(remoteFile.path, tmpFile.path, remoteFile.fileSize, false, 0, false, func, remoteFile);
+        gConnection.download(remoteFile.path, tmpFile.path, remoteFile.fileSize, false, 0, false, null, remoteFile);
+        launchProgram(extensionIndex, programIndex, tmpFile, remoteFile);
       }
     }
   } catch (ex) {


### PR DESCRIPTION
Fix for Opening (Reading) a remote file changes the file time to current time.
See Issue #95 for more information.

Not tested due to missing development environment.
