### PR TITLE
Add Pale Moon compatibility

### DIFF
--- a/src/chrome.manifest
+++ b/src/chrome.manifest
@@ -64,7 +64,8 @@ locale  fireftp vi-VN                            jar:chrome/fireftp.jar!/locale/
 locale  fireftp zh-CN                            jar:chrome/fireftp.jar!/locale/zh-CN/
 locale  fireftp zh-TW                            jar:chrome/fireftp.jar!/locale/zh-TW/
 skin    fireftp classic/1.0                      jar:chrome/fireftp.jar!/skin/
-overlay chrome://browser/content/browser.xul         chrome://fireftp/content/fireftpOverlay.xul
+overlay chrome://browser/content/browser.xul         chrome://fireftp/content/fireftpOverlay.xul application={ec8030f7-c20a-464f-9b0e-13a3a9e97384}
+overlay chrome://browser/content/browser.xul         chrome://fireftp/content/fireftpOverlay-pm.xul application={8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}
 overlay chrome://navigator/content/navigator.xul     chrome://fireftp/content/fireftpOverlay.xul
 style   chrome://global/content/customizeToolbar.xul chrome://fireftp/skin/overlay.css
 style   chrome://fireftp/content/fireftp.xul chrome://fireftp/skin/mac.css os=Darwin

--- a/src/chrome.manifest.in
+++ b/src/chrome.manifest.in
@@ -1,8 +1,9 @@
 content fireftp                                  jar:chrome/fireftp.jar!/content/
 locale  fireftp __l10n__                         jar:chrome/fireftp.jar!/locale/__l10n__/
 skin    fireftp classic/1.0                      jar:chrome/fireftp.jar!/skin/
-overlay chrome://browser/content/browser.xul         chrome://fireftp/content/fireftpOverlay.xul
 overlay chrome://navigator/content/navigator.xul     chrome://fireftp/content/fireftpOverlay.xul
+overlay chrome://browser/content/browser.xul         chrome://fireftp/content/fireftpOverlay.xul application={ec8030f7-c20a-464f-9b0e-13a3a9e97384}
+overlay chrome://browser/content/browser.xul         chrome://fireftp/content/fireftpOverlay-pm.xul application={8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}
 style   chrome://global/content/customizeToolbar.xul chrome://fireftp/skin/overlay.css
 style   chrome://fireftp/content/fireftp.xul chrome://fireftp/skin/mac.css os=Darwin
 interfaces components/nsIFireFTPUtils.xpt

--- a/src/chrome.manifest.master
+++ b/src/chrome.manifest.master
@@ -64,7 +64,8 @@ locale  fireftp vi-VN                            jar:chrome/fireftp.jar!/locale/
 locale  fireftp zh-CN                            jar:chrome/fireftp.jar!/locale/zh-CN/
 locale  fireftp zh-TW                            jar:chrome/fireftp.jar!/locale/zh-TW/
 skin    fireftp classic/1.0                      jar:chrome/fireftp.jar!/skin/
-overlay chrome://browser/content/browser.xul         chrome://fireftp/content/fireftpOverlay.xul
+overlay chrome://browser/content/browser.xul         chrome://fireftp/content/fireftpOverlay.xul application={ec8030f7-c20a-464f-9b0e-13a3a9e97384}
+overlay chrome://browser/content/browser.xul         chrome://fireftp/content/fireftpOverlay-pm.xul application={8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}
 overlay chrome://navigator/content/navigator.xul     chrome://fireftp/content/fireftpOverlay.xul
 style   chrome://global/content/customizeToolbar.xul chrome://fireftp/skin/overlay.css
 style   chrome://fireftp/content/fireftp.xul chrome://fireftp/skin/mac.css os=Darwin

--- a/src/content/fireftp-pm.xul
+++ b/src/content/fireftp-pm.xul
@@ -1,0 +1,518 @@
+<?xml version="1.0"?>
+
+<?xml-stylesheet href="chrome://global/skin/global.css"   type="text/css"?>
+<?xml-stylesheet href="chrome://fireftp/skin/fireftp.css" type="text/css"?>
+<?xml-stylesheet href="chrome://fireftp/skin/platform.css" type="text/css"?>
+
+<!DOCTYPE window SYSTEM "chrome://fireftp/locale/fireftp.dtd">
+<window id            = "fireftp-main-window"
+        title         = "FireFTP"
+        width         = "800"
+        height        = "600"
+        orient        = "vertical"
+        xmlns         = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+        xmlns:html    = "http://www.w3.org/1999/xhtml"
+        persist       = "width height screenX screenY sizemode"
+        onmousemove   = "treeHighlighter.mouseMove(event)"
+        onmousedown   = "treeHighlighter.mouseDown(event)"
+        onmouseup     = "treeHighlighter.mouseUp  (event)"
+        onload        = "startup()"
+        onunload      = "unload()"
+        onresize      = "doResizeReverseHack()"
+        disablefastfind="true">
+
+  <html:link rel="icon" href="chrome://fireftp/skin/icons/logo.png" style="display:none"/>
+
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/globals.js"/>
+
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/baseProtocol-pm.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/controlSocket.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/dataSocket.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/ftpController.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/baseObserver.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/ftpObserver.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/fxp.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/fxpObserver.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/transfer.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/transferObserver.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/ssh2.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/ssh2Observer.js"/>
+
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/kryptos.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Cipher/AES.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Cipher/Blowfish.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Cipher/DES3.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Cipher/ARC4.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Hash/baseHash.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Hash/SHA.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Hash/SHA256.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Hash/MD5.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Hash/HMAC.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/PublicKey/RSA.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/PublicKey/DSA.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Random/_UserFriendlyRNG.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Random/Fortuna/SHAd256.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Random/Fortuna/FortunaAccumulator.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Random/Fortuna/FortunaGenerator.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kryptos/Random/OSRNG/browser.js"/>
+
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/common.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/python_shim.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/BigInteger.js"/>
+
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/agent.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/auth_handler.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/ber.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/channel.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/client.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/compress.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/dsskey.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/file.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/hostkeys.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kex_gex.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/kex_group1.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/message.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/packet.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/pkey.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/rsakey.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/sftp_attr.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/sftp_client.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/sftp_file.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/sftp.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/ssh_exception.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/transport.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/util.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/connection/paramikojs/win_pageant.js"/>
+
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/common.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/diff.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/dragDrop.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/fileSort.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/loadUnload.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/log.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/misc.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/preferences.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/programs.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/queueTree.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/search.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/sessionsPasswords.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/treeHighlighter.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/treeSync.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/UIUpdate.js"/>
+
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/local/localFile.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/local/localTree.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/local/localDirTree.js"/>
+
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/remote/remoteTree.js"/>
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/remote/remoteDirTree.js"/>
+
+  <stringbundle id="strings" src="chrome://fireftp/locale/strings.properties"/>
+
+  <commandset>
+    <command id="cmd_connect"    oncommand="connect()"/>
+    <command id="cmd_disconnect" oncommand="disconnect()"/>
+    <command id="cmd_search"     oncommand="showSearch(true)"/>
+    <command id="cmd_dummy"      oncommand="return;"/>
+  </commandset>
+
+  <keyset>
+    <key id="key_transfer"      command="cmd_dummy"    keycode="VK_ENTER"/>
+    <key id="key_open"          command="cmd_dummy"    key="O" modifiers="accel"/>
+    <key id="key_url"           command="cmd_dummy"    key="U" modifiers="accel"/>
+    <key id="key_cut"           command="cmd_dummy"    key="X" modifiers="accel"/>
+    <key id="key_copy"          command="cmd_dummy"    key="C" modifiers="accel"/>
+    <key id="key_paste"         command="cmd_dummy"    key="V" modifiers="accel"/>
+    <key id="key_dir"           command="cmd_dummy"    key="D" modifiers="accel"/>
+    <key id="key_file"          command="cmd_dummy"    key="N" modifiers="accel"/>
+    <key id="key_remove"        command="cmd_dummy"    keycode="VK_DELETE"/>
+    <key id="key_rename"        command="cmd_dummy"    keycode="VK_F2"/>
+    <key id="key_properties"    command="cmd_dummy"    key="P" modifiers="accel"/>
+    <key id="key_search"        command="cmd_search"   key="F" modifiers="accel"/>
+  </keyset>
+
+  <!-- :::::::::::::::::::::::::::::: context menus :::::::::::::::::::::::::::::: -->
+
+  <popupset>
+    <menupopup id="localmenu" onpopupshowing="localTree.createContextMenu()">
+      <menuitem oncommand="localTree.openContainingFolder();"   label="&openContaining.label;"                                      id="localOpenCont"/>
+      <menuseparator                                                                                                                id="localOpenContSep"/>
+      <menuitem oncommand="new transfer().start(false);"        label="&upload.label;"              key="key_transfer"              id="localUpload"/>
+      <menuitem oncommand="localTree.launch()"                  label="&open.label;"                key="key_open"                  id="localOpen"/>
+      <menu label="&openwith.label;"                                                                                                id="localOpenWith">
+        <menupopup id="openWithMenu">
+        </menupopup>
+      </menu>
+      <menuitem oncommand="localTree.extract(false)"            label="&extractHere.label;"                                         id="extractHereContext"/>
+      <menuitem oncommand="localTree.extract(true)"             label="&extractTo.label;"                                           id="extractToContext"/>
+      <menuseparator/>
+      <menuitem oncommand="localTree.cut()"                     label="&cut.label;"                 key="key_cut"                   id="localCutContext"/>
+      <menuitem oncommand="localTree.copy()"                    label="&copy.label;"                key="key_copy"                  id="localCopyContext"/>
+      <menuitem oncommand="localTree.paste()"                   label="&paste.label;"               key="key_paste" disabled="true" id="localPasteContext"/>
+      <menuseparator/>
+      <menuitem oncommand="localTree.create(true)"              label="&makedir.label;"             key="key_dir"                   id="localCreateDir"/>
+      <menuitem oncommand="localTree.create(false)"             label="&makefile.label;"            key="key_file"                  id="localCreateFile"/>
+      <menuitem oncommand="localTree.remove()"                  label="&delete.label;"              key="key_remove"/>
+      <menuitem oncommand="localTree.rename()"                  label="&rename.label;"              key="key_rename"/>
+      <menuseparator/>
+      <menuitem oncommand="localTree.showProperties(false)"     label="&properties.label;"          key="key_properties"/>
+      <menuitem oncommand="localTree.showProperties(true)"      label="&rproperties.label;"                                         id="localRecursiveProperties"/>
+    </menupopup>
+    <menupopup id="remotemenu" onpopupshowing="remoteTree.createContextMenu()">
+      <menuitem oncommand="remoteTree.openContainingFolder();"  label="&openContaining.label;"                                      id="remoteOpenCont"/>
+      <menuseparator                                                                                                                id="remoteOpenContSep"/>
+      <menuitem oncommand="new transfer().start(true)"          label="&download.label;"            key="key_transfer"              id="remoteDownload"/>
+      <menuitem oncommand="remoteTree.launch()"                 label="&open.label;"                key="key_open"                  id="remoteOpen"/>
+      <menu label="&openwith.label;"                                                                                                id="remoteOpenWith">
+        <menupopup id="remoteOpenWithMenu">
+        </menupopup>
+      </menu>
+      <menuseparator/>
+      <menuitem oncommand="remoteTree.viewOnTheWeb()"           label="&viewweb.label;"                                             id="remoteWeb"/>
+      <menu label="&copyUrl.label;"                                                                                                 id="remoteCopyUrl">
+        <menupopup>
+          <menuitem oncommand="remoteTree.copyUrl(true)"        label="HTTP"                        key="key_url"/>
+          <menuitem oncommand="remoteTree.copyUrl(false)"       label="FTP"/>
+          <menuitem oncommand="remoteTree.copyUrl(false, true)" label="&copyUrlLogin.label;"/>
+        </menupopup>
+      </menu>
+      <menu label="FXP"                                                                                                             id="remoteFXP">
+        <menupopup id="remoteFXPMenu">
+        </menupopup>
+      </menu>
+      <menuseparator/>
+      <menuitem oncommand="remoteTree.cut()"                    label="&cut.label;"                 key="key_cut"                   id="remoteCutContext"/>
+      <menuitem oncommand="remoteTree.paste()"                  label="&paste.label;"               key="key_paste" disabled="true" id="remotePasteContext"/>
+      <menuseparator/>
+      <menuitem oncommand="remoteTree.create(true)"             label="&makedir.label;"             key="key_dir"                   id="remoteCreateDir"/>
+      <menuitem oncommand="remoteTree.create(false)"            label="&makefile.label;"            key="key_file"                  id="remoteCreateFile"/>
+      <menuitem oncommand="remoteTree.create(false, true)"      label="&symlink.label;"                                             id="remoteCreateSymlink"/>
+      <menuitem oncommand="remoteTree.remove()"                 label="&delete.label;"              key="key_remove"                id="remoteRemove"/>
+      <menuitem oncommand="remoteTree.rename()"                 label="&rename.label;"              key="key_rename"                id="remoteRename"/>
+      <menuseparator/>
+      <menuitem oncommand="remoteTree.showProperties(false)"    label="&properties.label;"          key="key_properties"            id="remoteProperties"/>
+      <menuitem oncommand="remoteTree.showProperties(true)"     label="&rproperties.label;"                                         id="remoteRecursiveProperties"/>
+    </menupopup>
+    <menupopup id="queuemenu" onpopupshowing="queueTree.createContextMenu()">
+      <menuitem oncommand="queueTree.retry();"                  label="&retry.label;"                                               id="queueRetry"/>
+      <menuitem oncommand="queueTree.cancel();"                 label="&cancel.label;"              key="key_remove"                id="queueCancel"/>
+      <menuseparator/>
+      <menuitem oncommand="doAbort()"                           label="&cancelAll.label;"                                           id="queueCancelAll"/>
+    </menupopup>
+    <menupopup id="advancedpopup"       position="after_start" onpopupshowing="toolsPopupMenu()">
+      <menuitem oncommand="showSearch(true)"                    label="&search.label;"              accesskey="&search.access;"     id="searchMenuItem" key="key_search"/>
+      <menuseparator/>
+      <menuitem oncommand="diff(false)"                         label="&diff.label;"                accesskey="&diff.access;"       id="diffMenuItem"/>
+      <menuitem oncommand="diff(true)"                          label="&recdiff.label;"             accesskey="&recdiff.access;"    id="recDiffMenuItem"/>
+      <menuseparator/>
+      <menuitem oncommand="showCustom(true)"                    label="&custom.label;"              accesskey="&custom.access;"     id="customMenuItem"/>
+      <menuseparator/>
+      <menuitem oncommand="importSites()"                       label="&import.label;"              accesskey="&import.access;"     id="importMenuItem"/>
+      <menuitem oncommand="exportSites()"                       label="&export.label;"              accesskey="&export.access;"     id="exportMenuItem"/>
+      <menuseparator/>
+      <menuitem oncommand="showPreferences()"                   label="&preferencestab.label;"      accesskey="&prefbutton.access;" id="prefbutton"/>
+    </menupopup>
+    <menupopup id="searchpopup"       position="before_start">
+      <menuitem oncommand="showSearchDates()" type="checkbox"   label="&searchDates.label;"         accesskey="&searchDates.access;"  id="searchDates"      persist="checked"/>
+      <menuitem type="checkbox"                                 label="&searchRegexp.label;"        accesskey="&searchRegexp.access;" id="searchRegExp"     persist="checked"/>
+      <menuitem type="checkbox"                                 label="&searchMatch.label;"         accesskey="&searchMatch.access;"  id="searchMatchCase"  persist="checked"/>
+      <menuitem type="checkbox"                                 label="&searchSubdir.label;"        accesskey="&searchSubdir.access;" id="searchSubdir"     persist="checked"/>
+    </menupopup>
+    <menupopup id="typepopup" position="before_start">
+      <menuitem type="checkbox" oncommand="onChangeType(0)"                     label="&auto.label;"    id="autoMode"    persist="checked"/>
+      <menuitem type="checkbox" oncommand="onChangeType(1)"                     label="&binary.label;"  id="binaryMode"  persist="checked"/>
+      <menuitem type="checkbox" oncommand="onChangeType(2)"                     label="&ascii.label;"   id="asciiMode"   persist="checked"/>
+    </menupopup>
+
+    <panel id="identity-popup" noautofocus="true" flip="both" position="bottomcenter topleft" type="arrow">
+      <hbox id="identity-popup-container" align="top">
+        <image id="identity-popup-icon"/>
+        <vbox id="identity-popup-content-box">
+          <description id="identity-popup-content-supplemental" class="identity-popup-description"/>
+          <description id="identity-popup-content-host" class="identity-popup-description"/>
+          <description id="identity-popup-content-verifier" class="identity-popup-description"/>
+          <hbox id="identity-popup-encryption" flex="1">
+            <vbox>
+              <image id="identity-popup-encryption-icon"/>
+            </vbox>
+            <description id="identity-popup-encryption-label" flex="1" class="identity-popup-description"/>
+          </hbox>
+        </vbox>
+      </hbox>
+    </panel>
+  </popupset>
+
+  <vbox flex="1">
+
+    <!-- :::::::::::::::::::::::::::::: main toolbar :::::::::::::::::::::::::::::: -->
+
+    <toolbar         id="main-toolbar"  align="center">
+      <toolbaritem   collapsed="true" id="folderItem">
+        <menulist    id="folder"                                                                       oncommand="onFolderChange(false, true)" width="175"/>
+      </toolbaritem>
+      <toolbaritem>
+        <menulist    id="account"       label="&accountlist.label;"    onclick="createAccount()"       oncommand="onAccountChange()" width="175"/>
+      </toolbaritem>
+      <toolbarbutton id="connectbutton"/>
+      <toolbarbutton id="editMenuItem"  label="&edit.label;"           accesskey="&edit.access;"       oncommand="editSite()"/>
+      <toolbarbutton id="abortbutton"   label="&abort.label;"          accesskey="&abort.access;"      oncommand="doAbort()"/>
+      <toolbarspacer flex="1"/>
+      <toolbarbutton id="logbutton"     label="&logtab.label;"         accesskey="&logbutton.access;"  oncommand="showLog()" type="checkbox" persist="checked"  autoCheck="false" />
+      <toolbarbutton id="advmenu"       label="&advanced.label;"       accesskey="&advanced.access;"   popup="advancedpopup"/>
+      <toolbarbutton id="helpbutton"    label="&help.label;"           accesskey="&helpbutton.access;"
+                     oncommand="runInFirefox('&help.url;')"/>
+    </toolbar>
+
+    <box flex="10">
+      <vbox id="localview" flex="1">
+
+        <!-- :::::::::::::::::::::::::::::: local toolbar :::::::::::::::::::::::::::::: -->
+
+        <toolbar id="localtoolbar">
+          <toolbarbutton class="upButton"      oncommand="localDirTree.cdup()"            tooltiptext="&parentdir.tip;"/>
+          <toolbarbutton class="refreshButton" oncommand="localTree.refresh(false, true)" tooltiptext="&refresh.tip;"/>
+          <textbox id                      = "localpath"
+                   flex                    = "1"
+                   tooltiptext             = "&localpath.tip;"
+                   onfocus                 = "onLocalPathFocus(event)"
+                   onblur                  = "onLocalPathBlur(event)"
+                   onkeypress              = "if (event.keyCode == 13) localDirTree.changeDir(this.value)"
+                   ontextentered           = "localDirTree.changeDir(this.value)"
+                   type                    = "autocomplete"
+                   tabscrolling            = "true"
+                   enablehistory           = "true"
+                   autocompletepopup       = "PopupAutoComplete"
+                   autocompletesearch      = "form-history"
+                   autocompletesearchparam = "localpath"/>
+          <toolbarbutton label="&browse.label;" oncommand="browseLocal()" accesskey="&browsebutton.access;"/>
+        </toolbar>
+
+        <!-- :::::::::::::::::::::::::::::: local file view :::::::::::::::::::::::::::::: -->
+
+        <hbox   width="1" flex="1" onmouseover="localTree.mouseOver(event)">
+          <tree id="localdirtree"  class="plain" flex="1" hidecolumnpicker="true" persist="collapsed"
+                onkeypress="localDirTree.keyPress(event)"
+                onselect  ="localDirTree.select(event)"
+                onclick   ="localDirTree.click(event)">
+            <treecols>
+              <treecol    id="localdirname" flex="1" primary="true" persist="width ordinal hidden"/>
+            </treecols>
+            <treechildren id="localdirtreechildren" class="dirTree" context="localdirmenu"
+                          ondragover="dragObserver.onDragOver(event)"
+                          ondrop="dragObserver.onDrop(event);"/>
+          </tree>
+          <splitter id="localsplitter" persist="state" collapse="before">
+            <grippy/>
+          </splitter>
+          <tree        id="localtree" class="plain" flex="2" enableColumnDrag="true" onkeypress="localTree.keyPress(event)" editable="true">
+            <treecols>
+              <treecol id="localname" label="&name.label;" flex="2" persist="width ordinal hidden sortDirection" sortDirection="ascending"/>
+              <splitter                class="tree-splitter"/>
+              <treecol id="localsize" label="&size.label;" flex="1" persist="width ordinal hidden sortDirection"/>
+              <splitter                class="tree-splitter"/>
+              <treecol id="localtype" label="&type.label;" flex="1" persist="width ordinal hidden sortDirection"/>
+              <splitter                class="tree-splitter"/>
+              <treecol id="localdate" label="&date.label;" flex="1" persist="width ordinal hidden sortDirection"/>
+              <splitter                class="tree-splitter"/>
+              <treecol id="localattr" label="&attr.label;" flex="1" persist="width ordinal hidden sortDirection" hidden="true"/>
+            </treecols>
+            <treechildren id="localtreechildren" class="fileTree" context="localmenu"
+                          ondblclick="localTree.dblClick(event)"
+                          onclick   ="localTree.click(event)"
+                          draggable="true"
+                          ondragstart="dragObserver.onDragStart(event)"
+                          ondragover="dragObserver.onDragOver(event)"
+                          ondrop="dragObserver.onDrop(event);"/>
+          </tree>
+        </hbox>
+      </vbox>
+
+      <splitter   id="leftsplitter"   collapse="before" resizebefore="closest" resizeafter="farthest" oncommand="setInterfaceMode()">
+      </splitter>
+      <vbox       pack="center">
+        <box      id="retrbutton">
+          <button id="retrieveButton" oncommand="new transfer().start(true)"  tooltiptext="&download.label;"/>
+        </box>
+        <box      id="storbutton">
+          <button id="storeButton"    oncommand="new transfer().start(false)" tooltiptext="&upload.label;"/>
+        </box>
+      </vbox>
+      <splitter   id="rightsplitter"  collapse="after" resizebefore="farthest" resizeafter="closest" oncommand="setInterfaceMode()">
+      </splitter>
+
+      <vbox id="remoteview" flex="1">
+
+        <!-- :::::::::::::::::::::::::::::: remote toolbar :::::::::::::::::::::::::::::: -->
+
+        <toolbar>
+          <toolbarbutton id="remoteUpButton"      class="upButton"      oncommand="remoteDirTree.cdup()" tooltiptext="&parentdir.tip;"/>
+          <toolbarbutton id="remoteRefreshButton" class="refreshButton" oncommand="remoteTree.refresh()" tooltiptext="&refresh.tip;"/>
+          <textbox id                      = "remotepath"
+                   value                   = "/"
+                   flex                    = "1"
+                   tooltiptext             = "&remotepath.tip;"
+                   onfocus                 = "onRemotePathFocus(event)"
+                   onblur                  = "onRemotePathBlur(event)"
+                   onkeypress              = "if (event.keyCode == 13) remoteDirTree.changeDir(this.value)"
+                   ontextentered           = "remoteDirTree.changeDir(this.value)"
+                   type                    = "autocomplete"
+                   tabscrolling            = "true"
+                   enablehistory           = "true"
+                   autocompletepopup       = "PopupAutoComplete"
+                   autocompletesearch      = "form-history"
+                   autocompletesearchparam = "remotepath">
+            <box id="identity-box" align="center" popup="identity-popup">
+              <deck id="page-proxy-deck">
+                <image id="page-proxy-button"/>
+                <image id="page-proxy-favicon" validate="never"
+                       onload="this.parentNode.selectedIndex = 1; event.stopPropagation();"
+                       onerror="this.removeAttribute('src'); this.parentNode.selectedIndex = 0;"/>
+              </deck>
+            </box>
+          </textbox>
+          <toolbarbutton id="remoteChangeButton" label="&change.label;" oncommand="remoteDirTree.changeDir(gRemotePath.value)" accesskey="&changebutton.access;"/>
+        </toolbar>
+
+        <!-- :::::::::::::::::::::::::::::: remote file view :::::::::::::::::::::::::::::: -->
+
+        <hbox   width="1" flex="1" onmouseover="remoteTree.mouseOver(event)">
+          <tree id="remotedirtree" class="plain" flex="1" hidecolumnpicker="true" persist="collapsed"
+                onkeypress="remoteDirTree.keyPress(event)"
+                onselect  ="remoteDirTree.select(event)"
+                onclick   ="remoteDirTree.click(event)">
+            <treecols>
+              <treecol    id="remotedirname" flex="1" primary="true" persist="width ordinal hidden"/>
+            </treecols>
+            <treechildren id="remotedirtreechildren" class="dirTree" context="remotedirmenu"
+                          ondragover="dragObserver.onDragOver(event)"
+                          ondrop="dragObserver.onDrop(event);"/>
+          </tree>
+          <splitter id="remotesplitter" collapse="before" persist="state">
+            <grippy/>
+          </splitter>
+          <tree        id="remotetree" class="plain" flex="2" enableColumnDrag="true" onkeypress="remoteTree.keyPress(event)" editable="true">
+            <treecols>
+              <treecol id="remotename" label="&name.label;" flex="2" persist="width ordinal hidden sortDirection" sortDirection="ascending"/>
+              <splitter                 class="tree-splitter"/>
+              <treecol id="remotesize" label="&size.label;" flex="1" persist="width ordinal hidden sortDirection"/>
+              <splitter                 class="tree-splitter"/>
+              <treecol id="remotetype" label="&type.label;" flex="1" persist="width ordinal hidden sortDirection"/>
+              <splitter                 class="tree-splitter"/>
+              <treecol id="remotedate" label="&date.label;" flex="1" persist="width ordinal hidden sortDirection"/>
+              <splitter                 class="tree-splitter"/>
+              <treecol id="remoteattr" label="&attr.label;" flex="1" persist="width ordinal hidden sortDirection" hidden="true"/>
+            </treecols>
+            <treechildren id="remotetreechildren" class="fileTree" context="remotemenu"
+                          ondblclick="remoteTree.dblClick(event)"
+                          onclick   ="remoteTree.click(event)"
+                          draggable="true"
+                          ondragstart="dragObserver.onDragStart(event)"
+                          ondragover="dragObserver.onDragOver(event)"
+                          ondrop="dragObserver.onDrop(event);"/>
+          </tree>
+        </hbox>
+      </vbox>
+    </box>
+
+    <!-- :::::::::::::::::::::::::::::: log/queue :::::::::::::::::::::::::::::: -->
+
+    <splitter id="logsplitter" collapse="after" resizebefore="closest" onmousedown="checkLogMouseDown()" onmouseup="checkLogCollapsed()">
+      <grippy onmouseup="setTimeout(checkLogCollapsed,0)"/>
+    </splitter>
+    <tabbox        id="logqueue" height="150" persist="height">
+      <tabpanels   id="lqtabs"   flex="1">
+        <tabpanel  flex="1">
+          <browser type="content" id="cmdlog" src="chrome://fireftp/content/blank.html" flex="1" persist="height"/>
+        </tabpanel>
+        <tabpanel flex="1">
+          <tree        id="queuetree" class="plain" flex="1" enableColumnDrag="true" onkeypress="queueTree.keyPress(event)">
+            <treecols>
+              <treecol id="queuesource"  label="&source.label;" flex="10" persist="width ordinal hidden"/>
+              <splitter                   class="tree-splitter"/>
+              <treecol id="queuedest"    label="&dest.label;"   flex="10" persist="width ordinal hidden"/>
+              <splitter                   class="tree-splitter"/>
+              <treecol id="queuebytes"   label="&bytes.label;"  flex="10" persist="width ordinal hidden"/>
+              <splitter                   class="tree-splitter"/>
+              <treecol id="queuepercent" label="&percent.tip;"  flex="3" persist="width ordinal hidden" type="progressmeter"/>
+              <splitter                   class="tree-splitter"/>
+              <treecol id="queueela"     label="&timeela.tip;"  flex="1" persist="width ordinal hidden"/>
+              <splitter                   class="tree-splitter"/>
+              <treecol id="queuerem"     label="&timerem.tip;"  flex="1" persist="width ordinal hidden"/>
+              <splitter                   class="tree-splitter"/>
+              <treecol id="queuerate"    label="&download.tip;" flex="1" persist="width ordinal hidden"/>
+              <splitter                   class="tree-splitter"/>
+              <treecol id="queuetype"    label="&type.label;"   flex="1" persist="width ordinal hidden"/>
+              <splitter                   class="tree-splitter"/>
+              <treecol id="queuestatus"  label="&status.label;" flex="1" persist="width ordinal hidden"/>
+            </treecols>
+            <treechildren id="queuetreechildren" class="fileTree" context="queuemenu"
+                          ondragover="dragObserver.onDragOver(event)"
+                          ondrop="dragObserver.onDrop(event);"/>
+          </tree>
+        </tabpanel>
+      </tabpanels>
+      <tabs  class="tabs-bottom" id="logQueueTabs" onclick="logQueueMode()" onkeypress="logQueueMode()">
+        <tab class="tab-bottom" label="&ltab.label;"/>
+        <tab class="tab-bottom" label="&qtab.label;"/>
+      </tabs>
+    </tabbox>
+
+  </vbox>
+
+  <!-- :::::::::::::::::::::::::::::: search toolbar :::::::::::::::::::::::::::::: -->
+
+  <toolbar      id="searchToolbar"  align="center" collapsed="true">
+    <toolbarbutton id="searchClosebutton" oncommand="showSearch(false);"/>
+    <hbox id="searchContainer">
+      <textbox  id="searchFile"        onkeypress="if (event.keyCode == 27) showSearch(false); else if (event.keyCode == 13) searchWrapper()"/>
+    </hbox>
+    <button     id="searchButton"      label="&searchButton.label;"  accesskey="&searchButton.access;"  oncommand="searchWrapper()" />
+    <radiogroup id="searchWhich" orient="horizontal" onselect="searchSelectType()">
+      <radio    id="searchLocal"       label="&searchLocal.label;"   accesskey="&searchLocal.access;"   persist="selected"/>
+      <radio    id="searchRemote"      label="&searchRemote.label;"  accesskey="&searchRemote.access;"  persist="selected"/>
+    </radiogroup>
+    <button     id="searchMenu"        label="&searchOptions.label;" accesskey="&searchOptions.access;" popup="searchpopup"/>
+    <hbox       id="searchDateBox" align="center">
+      <label      value="&searchFrom.label;" control="searchDateFrom"/>
+      <datepicker id="searchDateFrom"    type="popup"/>
+      <label      value="&searchTo.label;"   control="searchDateTo"/>
+      <datepicker id="searchDateTo"      type="popup"/>
+    </hbox>
+    <image      id="searchStatusIcon"/>
+    <label      id="searchStatus"/>
+  </toolbar>
+
+  <!-- :::::::::::::::::::::::::::: custom toolbar :::::::::::::::::::::::::::: -->
+
+  <toolbar      id="customToolbar"  align="center" collapsed="true">
+    <toolbarbutton id="customClosebutton" oncommand="showCustom(false);"/>
+    <hbox id="customContainer" flex="1">
+      <textbox  id="customCmd"
+                flex="1"
+                onkeypress="if (event.keyCode == 27) showCustom(false); else if (event.keyCode == 13) customExecute()"
+                onblur="showCustom(false);"
+                type                    = "autocomplete"
+                tabscrolling            = "true"
+                enablehistory           = "true"
+                autocompletepopup       = "PopupAutoComplete"
+                autocompletesearch      = "form-history"
+                autocompletesearchparam = "customcommands" />
+    </hbox>
+    <toolbarspacer />
+  </toolbar>
+
+  <!-- :::::::::::::::::::::::::::::: status bar :::::::::::::::::::::::::::::: -->
+
+  <statusbar>
+    <statusbarpanel  id="statustxt"       label="FireFTP"             flex="1"/>
+    <statusbarpanel  id="statusbytes"/>
+    <statusbarpanel  id="statustype"      tooltiptext="&type.tip;"    popup="typepopup"/>
+    <statusbarpanel  id="statuselapsed"   tooltiptext="&timeela.tip;"/>
+    <statusbarpanel  id="statusremaining" tooltiptext="&timerem.tip;"/>
+    <statusbarpanel  id="statusrate"      tooltiptext="&download.tip;"/>
+    <statusbarpanel  id="statusmeterpanel">
+      <progressmeter id="statusmeter"     tooltiptext="&percent.tip;" mode="normal" />
+    </statusbarpanel>
+  </statusbar>
+
+</window>

--- a/src/content/fireftpOverlay-pm.xul
+++ b/src/content/fireftpOverlay-pm.xul
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="chrome://fireftp/skin/overlay.css" type="text/css"?>
+
+<!DOCTYPE window SYSTEM "chrome://fireftp/locale/fireftp.dtd">
+<overlay id    = "fireftpOverlay"
+         xmlns = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+
+  <script type="application/x-javascript" src="chrome://fireftp/content/js/etc/fireftpOverlay-pm.js"/>
+
+  <!-- Firefox Tools menu -->
+  <menupopup       id="menu_ToolsPopup">
+    <menuitem      id="fireftptoolsmenu"   label="FireFTP"       oncommand="loadFireFTP()"
+                   accesskey="F"           insertafter="devToolsSeparator" class="menuitem-iconic"/>
+  </menupopup>
+
+  <!-- Firefox Tools -> WebDeveloper menu -->
+  <menupopup id="menuWebDeveloperPopup">
+    <menuitem      id="menu_webDeveloper_fireftp"   label="FireFTP"       oncommand="loadFireFTP()"
+                   accesskey="F"           insertbefore="webConsole"         class="menuitem-iconic"/>
+  </menupopup>
+
+  <!-- Firefox 4 Web Developer menu -->
+  <menupopup id="appmenu_webDeveloper_popup">
+    <menuitem      id="appmenu_fireftp"   label="FireFTP"       oncommand="loadFireFTP()"
+                   accesskey="F"           insertbefore="appmenu_webConsole"  class="menuitem-iconic" iconic="true" />
+    <menuseparator insertbefore="appmenu_webConsole" />
+  </menupopup>
+
+  <!-- SeaMonkey -->
+  <menupopup       id="taskPopup">
+    <menuitem      id="fireftptoolsmenu"   label="FireFTP"       oncommand="loadFireFTP()"
+                   accesskey="F"           insertafter="downloadmgr"
+                   class="menuitem-iconic"/>
+  </menupopup>
+
+  <menupopup       id="contentAreaContextMenu">
+    <menuitem      id="fireftpcontentarea" label="&viewFireFTP;" oncommand="loadFireFTPFromContentArea()"
+                   class="menuitem-iconic" />
+    <menuitem      id="fireftpcontextmenu" label="&openFireFTP;" oncommand="loadFireFTPFromContext()"
+                   class="menuitem-iconic" position="3"/>
+  </menupopup>
+
+  <toolbarpalette  id="BrowserToolbarPalette">
+    <toolbarbutton id="fireftp-button"     label="FireFTP"       oncommand="loadFireFTP()" onclick="if (event.button == 1) loadFireFTP()"
+                   class="toolbarbutton-1 chromeclass-toolbar-additional" tooltiptext="FireFTP"/>
+  </toolbarpalette>
+
+</overlay>

--- a/src/content/js/connection/baseProtocol-pm.js
+++ b/src/content/js/connection/baseProtocol-pm.js
@@ -1,0 +1,1175 @@
+// if you're actually interested in reusing this class for your app
+// it'd be a good idea to get in contact with me, Mime Cuvalo: mimecuvalo@gmail.com
+
+function baseProtocol() {
+  this.eventQueue = [];             // commands to be sent
+  this.trashQueue = [];             // once commands are read, throw them away here b/c we might have to recycle these if there is an error
+  this.listData   = [];             // holds data directory data from the LIST command
+}
+baseProtocol.prototype = {
+  // read-write variables
+  protocol             : "",
+  observer             : null,
+  host                 : "",
+  port                 : -1,
+  security             : "",
+  login                : "",
+  password             : "",
+  initialPath          : "",             // path we go to first onload
+  encoding             : "UTF-8",
+  type                 : '',             // what type of FTP connection is this? '' = master connection, 'fxp' = FXP/server-to-server, 'transfer' = transfer-only/slave connection
+  connNo               : 1,              // connection #
+  timezone             : 0,              // timezone offset
+  hiddenMode           : false,          // show hidden files if true
+  keepAliveMode        : true,           // keep the connection alive with NOOP's
+  networkTimeout       : 30,             // how many seconds b/f we consider the connection to be stale and dead
+  proxyHost            : "",
+  proxyPort            : 0,
+  proxyType            : "",
+  reconnectAttempts    : 40,             // how many times we should try reconnecting
+  reconnectInterval    : 10,             // number of seconds in b/w reconnect attempts
+  reconnectMode        : true,           // true if we want to attempt reconnecting
+  sessionsMode         : true,           // true if we're caching directory data
+  timestampsMode       : false,          // true if we try to keep timestamps in sync
+  useCompression       : true,           // true if we try to do compression
+  integrityMode        : true,           // true if we try to do integrity checks
+  errorConnectStr      : "Unable to make a connection.  Please try again.", // set to error msg that you'd like to show for a connection error
+  errorXCheckFail      : "The transfer of this file was unsuccessful and resulted in a corrupted file. It is recommended to restart this transfer.",  // an integrity check failure
+  passNotShown         : "(password not shown)",                            // set to text you'd like to show in place of password
+  l10nMonths           : new Array("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"), // used in display localized months
+
+  // read-only variables
+  transportService     : Components.classes["@mozilla.org/network/socket-transport-service;1"].getService(Components.interfaces.nsISocketTransportService),
+  proxyService         : Components.classes["@mozilla.org/network/protocol-proxy-service;1"].getService  (Components.interfaces.nsIProtocolProxyService),
+  cacheService         : Components.classes["@mozilla.org/network/cache-service;1"].getService           (Components.interfaces.nsICacheService),
+  toUTF8               : Components.classes["@mozilla.org/intl/utf8converterservice;1"].getService       (Components.interfaces.nsIUTF8ConverterService),
+  fromUTF8             : Components.classes["@mozilla.org/intl/scriptableunicodeconverter"].getService   (Components.interfaces.nsIScriptableUnicodeConverter),
+  isAttemptingConnect  : false,
+  isConnected          : false,          // are we connected?
+  isReady              : false,          // are we busy writing/reading the control socket?
+  isReconnecting       : false,          // are we attempting a reconnect?
+  legitClose           : true,           // are we the ones initiating the close or is it a network error
+  reconnectsLeft       : 0,              // how many times more to try reconnecting
+  networkTimeoutID     : 0,              // a counter increasing with each read and write
+  transferID           : 0,              // a counter increasing with each transfer
+  queueID              : 0,              // another counter increasing with each transfer
+
+  controlTransport     : null,
+  controlInstream      : null,
+  controlOutstream     : null,
+  dataSocket           : null,           // only used with (*ahem* lame *ahem*) protocols like FTP that need a second socket 
+  
+  doingCmdBatch        : false,
+
+  connectedHost        : "",             // name of the host we connect to plus username
+  localRefreshLater    : '',
+  remoteRefreshLater   : '',
+  waitToRefresh        : false,
+  currentWorkingDir    : "",             // directory that we're currently, uh, working with
+  version              : "",  // version of this class - used to avoid collisions in cache
+  remoteMonths         : "Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec",      // used in parsing months from list data
+
+  // functions that should be implemented by derived classes
+  connect                : function(reconnect) { alert('NOT_IMPLEMENTED'); },
+  cleanup                : function(isAbort) { alert('NOT_IMPLEMENTED'); },      // cleanup internal variables
+  keepAlive              : function() { alert('NOT_IMPLEMENTED'); },
+  isWriteUnnecessary     : function(cmd, parameter) { alert('NOT_IMPLEMENTED'); },
+  processWriteCommand    : function(cmd, parameter) { alert('NOT_IMPLEMENTED'); },
+  isValidTimeoutCommand  : function(cmd) { alert('NOT_IMPLEMENTED'); },
+  getCommandInfo         : function(cmd) { alert('NOT_IMPLEMENTED'); },
+  readControl            : function(buffer) { alert('NOT_IMPLEMENTED'); },
+  changeWorkingDirectory : function(path, callback) { alert('NOT_IMPLEMENTED'); },
+  makeDirectory          : function(path, callback, recursive, errorCallback) { alert('NOT_IMPLEMENTED'); },
+  makeBlankFile          : function(path, callback, errorCallback) { alert('NOT_IMPLEMENTED'); },
+  remove                 : function(isDirectory, path, callback) { alert('NOT_IMPLEMENTED'); },
+  rename                 : function(oldName, newName, callback, isDir, errorCallback) { alert('NOT_IMPLEMENTED'); },
+  changePermissions      : function(permissions, path, callback) { alert('NOT_IMPLEMENTED'); },
+  custom                 : function(cmd) { alert('NOT_IMPLEMENTED'); },
+  list                   : function(path, callback, skipCache, recursive, fxp, eventualGoalPath) { alert('NOT_IMPLEMENTED'); },
+  download               : function(remotePath, localPath, remoteSize, resume, localSize, isSymlink, callback, remoteFile) { alert('NOT_IMPLEMENTED'); },
+  upload                 : function(localPath, remotePath, resume, localSize, remoteSize, callback, disableTimestampSync, errorCallback, file) { alert('NOT_IMPLEMENTED'); },
+  checkDataTimeout       : function(isDownload, id, bytes) { alert('NOT_IMPLEMENTED'); },
+  isListing              : function() { alert('NOT_IMPLEMENTED'); },
+  recoverFromDisaster    : function() { alert('NOT_IMPLEMENTED'); },
+
+  // optional functions to override
+  resetReconnectState : function() { },                                          // called when starting to reconnect, should reset certain internal variables to have clean slate for fresh connection
+  sendQuitCommand : function(legitClose) { },                                    // called when shutting down the connection
+  sendAbortCommand : function() { },                                             // called when aborting
+  doExec : function(cmd, options) { },                                           // execute write command
+
+  // private functions that should not be overridden
+  // if a function has a _ prefix, it should be called by corresponding functions (without _ prefix) in derived classes
+
+  setupConnect : function(reconnect) {
+    if (!reconnect) {                                                            // this is not a reconnection attempt
+      this.isReconnecting = false;
+      this.reconnectsLeft = parseInt(this.reconnectAttempts);
+
+      if (!this.reconnectsLeft || this.reconnectsLeft < 1) {
+        this.reconnectsLeft = 1;
+      }
+    }
+
+    if (!this.eventQueue.length || this.eventQueue[0].cmd != "welcome") {
+      this.unshiftEventQueue("welcome", "", "");                                 // wait for welcome message first
+    }
+
+    ++this.networkTimeoutID;                                                     // just in case we have timeouts from previous connection
+    ++this.transferID;
+    this.isAttemptingConnect = true;
+  },
+
+  onConnected : function() {
+    this.isConnected       = true;                                               // good to go
+    this.isAttemptingConnect = false;
+
+    this.observer.onConnected();
+
+    this.isReconnecting    = false;
+    this.reconnectsLeft    = parseInt(this.reconnectAttempts);                   // setup reconnection settings
+
+    if (!this.reconnectsLeft || this.reconnectsLeft < 1) {
+      this.reconnectsLeft = 1;
+    }
+  },
+
+  disconnect : function() {                                                      // user has requested an explicit disconnect
+    this.legitClose = true;                                                      // this close() is ok, don't try to reconnect
+    this.isConnected = false;
+    this.cleanup();
+
+    if (!(this.eventQueue.length && this.eventQueue[0].cmd == "welcome") || this.protocol == "ssh2") {
+      this.sendQuitCommand(true);
+    }
+
+    if (this.dataSocket) {
+      this.dataSocket.kill();
+      this.dataSocket = null;
+    }
+  },
+
+  onDisconnect : function() {                                                    // called when disconnected
+    if ((!this.isConnected && !this.legitClose) || this.isAttemptingConnect) {   // no route to host
+      this.observer.onAppendLog(this.errorConnectStr, 'error', "error");
+    }
+
+    this.isConnected = false;
+    this.isAttemptingConnect = false;
+
+    if (this.dataSocket) {                                                       // kill ftp data socket
+      this.dataSocket.kill();
+      this.dataSocket = null;
+    }
+
+    this.kill();
+
+    this.observer.onDisconnected(!this.legitClose && this.reconnectMode && this.reconnectsLeft > 0);
+    this.observer.onIsReadyChange(true);
+
+    if (!this.legitClose && this.reconnectMode) {                                // try reconnecting
+      this.resetReconnectState();
+
+      if (this.reconnectsLeft < 1) {
+        this.isReconnecting = false;
+        if (this.eventQueue.length && this.eventQueue[0].cmd == "welcome") {
+          this.eventQueue.shift();
+        }
+      } else {
+        this.isReconnecting = true;
+
+        this.observer.onReconnecting();
+
+        var self = this;
+        var func = function() { self.reconnect(); };
+        setTimeout(func, this.reconnectInterval * 1000);
+      }
+    } else {
+      this.legitClose = true;
+      this.cleanup();
+    }
+  },
+
+  kill : function() {
+    try {
+      this.controlInstream.close();
+    } catch(ex) {
+      this.observer.onDebug(ex);
+    }
+
+    try {
+      this.controlOutstream.close();
+    } catch(ex) {
+      this.observer.onDebug(ex);
+    }
+  },
+
+  _cleanup : function(isAbort) {
+    this.eventQueue         = new Array();
+    this.trashQueue         = new Array();
+    this.currentWorkingDir  = "";
+    this.localRefreshLater  = "";
+    this.remoteRefreshLater = "";
+    this.waitToRefresh      = false;
+    this.isReady            = false;
+
+    ++this.networkTimeoutID;
+    ++this.transferID;
+
+    this.observer.onClearQueue();
+  },
+
+  reconnect : function()  {                                                      // ahhhh! our precious connection has been lost,
+    if (!this.isReconnecting) {                                                  // must...get it...back...our...precious
+      return;
+    }
+
+    --this.reconnectsLeft;
+
+    this.connect(true);
+  },
+
+  abort : function(forceKill) {
+    this.isReconnecting     = false;
+
+    if (this.dataSocket) {
+      this.dataSocket.progressEventSink.bytesTotal = 0;                          // stop uploads
+      this.dataSocket.dataListener.bytesTotal      = 0;                          // stop downloads
+    }
+
+    this.cleanup(true);
+
+    if (!this.isConnected) {
+      return;
+    }
+
+    if (forceKill) {
+      this.sendAbortCommand();
+    }
+
+    //XXX this.writeControl("ABOR");                                             // ABOR does not seem to stop the connection in most cases
+    if (this.dataSocket) {                                                       // so this is a more direct approach
+      this.dataSocket.kill();
+      this.dataSocket = null;
+    } else {
+      this.isReady = true;
+    }
+
+    this.addEventQueue("aborted");
+
+    this.observer.onAbort();
+  },
+
+  cancel : function(forceKill) {                                                 // cancel current transfer
+    if (this.dataSocket) {
+      this.dataSocket.progressEventSink.bytesTotal = 0;                          // stop uploads
+      this.dataSocket.dataListener.bytesTotal      = 0;                          // stop downloads
+    }
+
+    this.trashQueue = new Array();
+
+    if (forceKill) {
+      this.sendAbortCommand();
+    }
+
+    //XXX this.writeControl("ABOR");                                             // ABOR does not seem to stop the connection in most cases
+    var dId;
+    if (this.dataSocket && this.isConnected) {                                   // so this is a more direct approach
+      this.dataSocket.kill();
+      dId = this.dataSocket.id;
+      this.dataSocket = null;
+    }
+
+    if (this.transferProgress) {
+      dId = this.transferProgress.id;
+      this.transferProgress.id = '';
+      this.transferProgress.bytesTotal = 0;
+    }
+
+    for (var x = 0; x < this.eventQueue.length; ++x) {
+      if (this.eventQueue[x].cmd == "transferEnd" && dId == this.eventQueue[x].options.id) {
+        this.eventQueue.splice(0, x + 1);
+        this.observer.onRemoveQueue(dId);
+        break;
+      }
+    }
+
+    if (this.isConnected && this.protocol != "ssh2") {
+      this.unshiftEventQueue("aborted");
+    }
+  },
+
+  loginAccepted : function() {
+    if (this.legitClose) {
+      this.observer.onWelcomed();
+    }
+
+    var newConnectedHost = this.login + "@" + this.host;
+
+    this.observer.onLoginAccepted(newConnectedHost != this.connectedHost);
+
+    if (newConnectedHost != this.connectedHost) {
+      this.legitClose = true;
+    }
+
+    this.connectedHost = newConnectedHost;                                       // switching to a different host or different login
+
+    if (!this.legitClose) {
+      this.recoverFromDisaster();                                                // recover from previous disaster
+      return false;
+    }
+
+    this.legitClose   = false;
+
+    return true;                                                                 // proceed normally
+  },
+
+  loginDenied : function(buffer) {
+    if (this.type == 'transfer') {
+      this.observer.onLoginDenied();
+    }
+
+    this.cleanup();                                                              // login failed, cleanup variables
+
+    if (this.type != 'transfer' && this.type != 'bad') {
+      this.observer.onError(buffer);
+    }
+
+    this.isConnected = false;
+
+    this.kill();
+
+    if (this.type == 'transfer') {
+      this.type = 'bad';
+    }
+
+    if (this.type != 'transfer' && this.type != 'bad') {
+      var self = this;
+      var func = function() { self.observer.onLoginDenied(); };
+      setTimeout(func, 0);
+    }
+  },
+
+  checkTimeout : function(id, cmd) {
+    if (this.isConnected && this.networkTimeoutID == id && this.eventQueue.length && this.eventQueue[0].cmd.indexOf(cmd) != -1) {
+      this.resetConnection();
+    }
+  },
+
+  resetConnection : function() {
+    this.legitClose = false;                                                     // still stuck on a command so, try to restart the connection the hard way
+
+    this.sendQuitCommand();
+
+    if (this.dataSocket) {
+      this.dataSocket.kill();
+      this.dataSocket = null;
+    }
+
+    this.kill();
+  },
+
+  addEventQueue : function(cmd, parameter, callback, options, exec) {            // this just creates a new queue item
+    this.eventQueue.push(   { cmd: cmd, parameter: parameter || '', callback: callback || null, options: options || {}, exec: exec || null });
+  },
+
+  unshiftEventQueue : function(cmd, parameter, callback, options, exec) {        // ditto
+    this.eventQueue.unshift({ cmd: cmd, parameter: parameter || '', callback: callback || null, options: options || {}, exec: exec || null });
+  },
+
+  beginCmdBatch : function() {
+    this.doingCmdBatch = true;
+  },
+
+  writeControlWrapper : function() {
+    if (!this.doingCmdBatch) {
+      this.writeControl();
+    }
+  },
+
+  endCmdBatch : function() {
+    this.doingCmdBatch = false;
+    this.writeControl();
+  },
+
+  refresh : function() {
+    var stillWorking = false;
+    for (var y = 0; y < gMaxCon; ++y) {
+      if (gConnections[y].eventQueue.length) {
+        stillWorking = true;
+      }
+    }
+    if (this.waitToRefresh || stillWorking) {
+      var self = this;
+      var func = function() { self.refresh(); };
+      setTimeout(func, 1000);
+      return;
+    } else if (this.eventQueue.length) {
+      return;
+    }
+
+    if (this.localRefreshLater) {
+      var dir                 = new String(this.localRefreshLater);
+      this.localRefreshLater  = "";
+
+      this.observer.onShouldRefresh(true, false, dir);
+    }
+
+    if (this.remoteRefreshLater) {
+      var dir                 = new String(this.remoteRefreshLater);
+      this.remoteRefreshLater = "";
+
+      this.observer.onShouldRefresh(false, true, dir);
+    }
+  },
+
+  writeControl : function(cmd) {
+    try {
+      if (!this.isReady || (!cmd && !this.eventQueue.length)) {
+        return;
+      }
+
+      var parameter;
+      var callback;
+      var options;
+      var exec;
+
+      if (!cmd) {
+        cmd        = this.eventQueue[0].cmd;
+        parameter  = this.eventQueue[0].parameter;
+        callback   = this.eventQueue[0].callback;
+        options    = this.eventQueue[0].options;
+        exec       = this.eventQueue[0].exec;
+      }
+
+      if (cmd == "custom") {
+        cmd       = parameter;
+        parameter = "";
+      }
+
+      var redudantCommand = this.isWriteUnnecessary(cmd, parameter);
+
+      while (cmd == "aborted" || cmd == "goodbye" || cmd == "transferBegin" || cmd == "transferEnd" || redudantCommand) {
+        if (redudantCommand) {
+          this.trashQueue.push(this.eventQueue[0]);
+        }
+
+        if (cmd == "transferEnd") {
+          this.observer.onRemoveQueue(options.id);
+        }
+
+        this.eventQueue.shift();
+
+        if (this.eventQueue.length) {
+          cmd        = this.eventQueue[0].cmd;
+          parameter  = this.eventQueue[0].parameter;
+          callback   = this.eventQueue[0].callback;
+          options    = this.eventQueue[0].options;
+          exec       = this.eventQueue[0].exec;
+        } else {
+          return;
+        }
+
+        redudantCommand = this.isWriteUnnecessary(cmd, parameter);
+      }
+
+      this.isReady = false;
+
+      this.observer.onIsReadyChange(false);
+
+      var processedCommands = this.processWriteCommand(cmd, parameter);
+      cmd = processedCommands.cmd;
+      parameter = processedCommands.parameter;
+
+      var outputData = cmd + (parameter ? (' ' + parameter) : '') + "\r\n";      // le original bug fix! - thanks to devin
+
+      if (exec) {
+        var success = this.doExec(exec, options);
+        if (!success) {
+          return;
+        }
+      } else {
+        try {
+          outputData   = this.fromUTF8.ConvertFromUnicode(outputData) + this.fromUTF8.Finish();
+        } catch (ex) {
+          this.observer.onDebug(ex);
+        }
+
+        this.controlOutstream.write(outputData, outputData.length);                // write!
+      }
+
+      var self = this;
+      if (this.isValidTimeoutCommand(cmd)) {
+        ++this.networkTimeoutID;                                                   // this checks for timeout
+        var currentTimeout = this.networkTimeoutID;
+        var func           = function() { self.checkTimeout(currentTimeout, cmd); };
+        setTimeout(func, this.networkTimeout * 1000);
+      }
+
+      var commandInfo = this.getCommandInfo(cmd);
+      if (commandInfo.isTransferCmd) {
+        ++this.transferID;
+        var currentId    = this.transferID;
+        var func         = function() { self.checkDataTimeout(commandInfo.isDownload, currentId, 0); };
+        setTimeout(func, this.networkTimeout * 1000);
+      }
+
+      outputData = cmd + (parameter ? (' ' + parameter) : '');                   // write it out to the log
+
+      if (commandInfo.skipLog) {
+        // do nothing
+      } else if (!commandInfo.isPrivate) {
+        this.observer.onAppendLog("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + outputData, 'output', "info");
+      } else {
+        this.observer.onAppendLog("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + cmd + " " + this.passNotShown, 'output', "info");
+      }
+
+    } catch(ex) {
+      this.observer.onDebug(ex);
+      this.observer.onError(this.errorConnectStr);
+    }
+  },
+
+  nextCommand : function() {
+    this.isReady = true;
+
+    this.observer.onIsReadyChange(true);
+
+    if (this.eventQueue.length && this.eventQueue[0].cmd != "welcome") {         // start the next command
+      this.writeControl();
+    } else {
+      this.refresh();
+    }
+  },
+
+  handleCWDResponse : function(success, cmd, parameter, callback, options, exec, buffer) {
+    if (success) {
+      this.currentWorkingDir = parameter;
+
+      this.observer.onChangeDir(parameter, options.dontUpdateView);              // else navigate to the directory
+
+      if (callback) {
+        callback(true);
+      }
+    } else {                                                                     // if it's not a directory
+      if (this.type != 'transfer' && options.isUploading) {
+        while (this.eventQueue.length) {
+          if (this.eventQueue[0].cmd == "transferEnd") {
+            this.observer.onRemoveQueue(this.eventQueue[0].options.id);
+            this.observer.onTransferFail(this.eventQueue[0].options, buffer);
+            this.eventQueue.shift();
+            break;
+          }
+
+          this.eventQueue.shift();
+        }
+      }
+
+      if (callback) {
+        callback(false);
+      } else if (this.type == 'transfer') {
+        if (buffer) {
+          this.observer.onDebug(buffer);
+        }
+        this.unshiftEventQueue(cmd, parameter, callback, options, exec);
+        this.makeDirectory(parameter, "", true);
+      } else {
+        this.observer.onDirNotFound(buffer);
+
+        this.observer.onError(buffer);
+      }
+    }
+  },
+
+  parseListData : function(data, path, skipEncoding) {
+    /* Unix style:                     drwxr-xr-x  1 user01 ftp  512    Jan 29 23:32 prog
+     * Alternate Unix style:           drwxr-xr-x  1 user01 ftp  512    Jan 29 1997  prog
+     * Alternate Unix style:           drwxr-xr-x  1 1      1    512    Jan 29 23:32 prog
+     * SunOS style:                    drwxr-xr-x+ 1 1      1    512    Jan 29 23:32 prog
+     * A symbolic link in Unix style:  lrwxr-xr-x  1 user01 ftp  512    Jan 29 23:32 prog -> prog2000
+     * AIX style:                      drwxr-xr-x  1 user01 ftp  512    05 Nov 2003  prog
+     * Novell style:                   drwxr-xr-x  1 user01      512    Jan 29 23:32 prog
+     * Weird style:                    drwxr-xr-x  1 user5424867        Jan 29 23:32 prog, where 5424867 is the size
+     * Weird style 2:                  drwxr-xr-x  1 user01 anon5424867 Jan 11 12:48 prog, where 5424867 is the size
+     * MS-DOS style:                   01-29-97 11:32PM <DIR> prog
+     * OS/2 style:                     0           DIR 01-29-97  23:32  PROG
+     * OS/2 style:                     2243        RA  04-05-103 00:22  PJL
+     * OS/2 style:                     60              11-18-104 06:54  chkdsk.log
+     *
+     * MLSD style: type=file;size=6106;modify=20070223082414;UNIX.mode=0644;UNIX.uid=32257;UNIX.gid=32259;unique=808g154c727; prog
+     *             type=dir;sizd=4096;modify=20070218021044;UNIX.mode=0755;UNIX.uid=32257;UNIX.gid=32259;unique=808g1550003; prog
+     *             type=file;size=4096;modify=20070218021044;UNIX.mode=07755;UNIX.uid=32257;UNIX.gid=32259;unique=808g1550003; prog
+     *             type=OS.unix=slink:/blah;size=4096;modify=20070218021044;UNIX.mode=0755;UNIX.uid=32257;UNIX.gid=32259;unique=808g1550003; prog
+     */
+
+    if (!skipEncoding) {
+      try {
+        data = this.toUTF8.convertStringToUTF8(data, this.encoding, 1);
+      } catch (ex) {
+        this.observer.onDebug(ex);
+      }
+    }
+
+    this.observer.onDebug(data.replace(/</g, '&lt;').replace(/>/g, '&gt;'), "DEBUG");
+
+    var items   = data.replace(/\r\n/g, "\n").split("\n");
+    items       = items.filter(this.removeBlanks);
+    var curDate = new Date();
+
+    if (items.length) {                                                          // some ftp servers send 'count <number>' or 'total <number>' first
+      var firstLine = items[0].toLowerCase();
+      if (firstLine.indexOf("count") == 0 || firstLine.indexOf("total") == 0 || firstLine.indexOf("listing directory") == 0 || (!this.featMLSD && items[0].split(" ").filter(this.removeBlanks).length == 2)) {
+        items.shift();                                                           // could be in german or croatian or what have you
+      }
+    }
+
+    for (var x = 0; x < items.length; ++x) {
+      try {
+        if (!items[x]) {                                                           // some servers put in blank lines b/w entries, aw, for cryin' out loud
+          items.splice(x, 1);
+          --x;
+          continue;
+        }
+
+        items[x] = items[x].replace(/^\s+/, "");                                   // @*$% - some servers put blanks in front, do trimming on front
+
+        var temp = items[x];                                                       // account for collisions:  drwxr-xr-x1017 user01
+
+        if (!this.featMLSD) {
+          if (!parseInt(items[x].charAt(0)) && items[x].charAt(0) != '0' && items[x].charAt(10) == '+') {     // drwxr-xr-x+ - get rid of the plus sign
+            items[x] = this.setCharAt(items[x], 10, ' ');
+          }
+
+          if (!parseInt(items[x].charAt(0)) && items[x].charAt(0) != '0' && items[x].charAt(10) != ' ') {     // this is mimicked below if weird style
+            items[x] = items[x].substring(0, 10) + ' ' + items[x].substring(10, items[x].length);
+          }
+
+          items[x]   = items[x].split(" ").filter(this.removeBlanks);
+        }
+
+        if (this.featMLSD) {                                                       // MLSD-standard style
+          var newItem    = { permissions : "----------",
+                             hardLink    : "",
+                             user        : "",
+                             group       : "",
+                             fileSize    : "0",
+                             date        : "",
+                             leafName    : "",
+                             isDir       : false,
+                             isDirectory : function() { return this.isDir },
+                             isSymlink   : function() { return this.symlink != "" },
+                             symlink     : "",
+                             path        : "" };
+
+          var pathname     = items[x].split("; ");
+          newItem.leafName = '';
+          for (var y = 1; y < pathname.length; ++y) {
+            newItem.leafName += (y == 1 ? '' : '; ') + pathname[y];
+          }
+
+          // some servers place full path for the filename...arrrgh /users/www/blah has to be just 'blah'
+          newItem.leafName = newItem.leafName.substring(newItem.leafName.lastIndexOf("/") + 1);
+
+          newItem.path     = this.constructPath(path, newItem.leafName);
+
+          items[x] = pathname[0];
+          items[x] = items[x].split(";");
+          var skip = false;
+
+          for (var y = 0; y < items[x].length; ++y) {
+            if (!items[x][y]) {
+              continue;
+            }
+
+            var fact = items[x][y].split('=');
+            if (fact.length < 2 || !fact[0] || !fact[1]) {
+              continue;
+            }
+
+            var factName = fact[0].toLowerCase();
+            var factVal  = fact[1];
+
+            switch (factName) {
+              case "type":
+                if (factVal == "pdir" || factVal == "cdir") {
+                  skip = true;
+                } else if (factVal == "dir") {
+                  newItem.isDir = true;
+                  newItem.permissions = this.setCharAt(newItem.permissions, 0, 'd');
+                } else if (items[x][y].substring(5).indexOf("OS.unix=slink:") == 0) {
+                  newItem.symlink = items[x][y].substring(19);
+                  newItem.permissions = this.setCharAt(newItem.permissions, 0, 'l');
+                } else if (factVal != "file") {
+                  skip = true;
+                }
+                break;
+              case "size":
+              case "sizd":
+                newItem.fileSize = factVal;
+                break;
+              case "modify":
+                var dateString = factVal.substr(0, 4) + " " + factVal.substr(4,  2) + " " + factVal.substr(6,  2) + " "
+                               + factVal.substr(8, 2) + ":" + factVal.substr(10, 2) + ":" + factVal.substr(12, 2) + " GMT";
+                var zeDate = new Date(dateString);
+                zeDate.setMinutes(zeDate.getMinutes() + this.timezone);
+                var timeOrYear = new Date() - zeDate > 15600000000 ? zeDate.getFullYear()    // roughly 6 months
+                               : this.zeroPadTime(zeDate.getHours()) + ":" + this.zeroPadTime(zeDate.getMinutes());
+                newItem.date = this.l10nMonths[zeDate.getMonth()] + ' ' + zeDate.getDate() + ' ' + timeOrYear;
+                newItem.lastModifiedTime = zeDate.getTime();
+                break;
+              case "unix.mode":
+                var offset = factVal.length == 5 ? 1 : 0;
+                var sticky = this.zeroPad(parseInt(factVal[0 + offset]).toString(2));
+                var owner  = this.zeroPad(parseInt(factVal[1 + offset]).toString(2));
+                var group  = this.zeroPad(parseInt(factVal[2 + offset]).toString(2));
+                var pub    = this.zeroPad(parseInt(factVal[3 + offset]).toString(2));
+                newItem.permissions = this.setCharAt(newItem.permissions, 1, owner[0]  == '1' ? 'r' : '-');
+                newItem.permissions = this.setCharAt(newItem.permissions, 2, owner[1]  == '1' ? 'w' : '-');
+                newItem.permissions = this.setCharAt(newItem.permissions, 3, sticky[0] == '1' ? (owner[2] == '1' ? 's' : 'S')
+                                                                                              : (owner[2] == '1' ? 'x' : '-'));
+                newItem.permissions = this.setCharAt(newItem.permissions, 4, group[0]  == '1' ? 'r' : '-');
+                newItem.permissions = this.setCharAt(newItem.permissions, 5, group[1]  == '1' ? 'w' : '-');
+                newItem.permissions = this.setCharAt(newItem.permissions, 6, sticky[1] == '1' ? (group[2] == '1' ? 's' : 'S')
+                                                                                              : (group[2] == '1' ? 'x' : '-'));
+                newItem.permissions = this.setCharAt(newItem.permissions, 7, pub[0]    == '1' ? 'r' : '-');
+                newItem.permissions = this.setCharAt(newItem.permissions, 8, pub[1]    == '1' ? 'w' : '-');
+                newItem.permissions = this.setCharAt(newItem.permissions, 9, sticky[2] == '1' ? (pub[2]   == '1' ? 't' : 'T')
+                                                                                              : (pub[2]   == '1' ? 'x' : '-'));
+                break;
+              case "unix.uid":
+                newItem.user = factVal;
+                break;
+              case "unix.gid":
+                newItem.group = factVal;
+                break;
+              default:
+                break;
+            }
+
+            if (skip) {
+              break;
+            }
+          }
+
+          if (skip) {
+            items.splice(x, 1);
+            --x;
+            continue;
+          }
+
+          items[x] = newItem;
+        } else if (!parseInt(items[x][0].charAt(0)) && items[x][0].charAt(0) != '0')  {   // unix style - so much simpler with you guys
+          var offset = 0;
+
+          if (items[x][3].search(this.remoteMonths) != -1 && items[x][5].search(this.remoteMonths) == -1) {
+            var weird = temp;                                                      // added to support weird servers
+
+            if (weird.charAt(10) != ' ') {                                         // same as above code
+              weird = weird.substring(0, 10) + ' ' + weird.substring(10, weird.length);
+            }
+
+            var weirdIndex = 0;
+
+            for (var y = 0; y < items[x][2].length; ++y) {
+              if (parseInt(items[x][2].charAt(y))) {
+                weirdIndex = weird.indexOf(items[x][2]) + y;
+                break;
+              }
+            }
+
+            weird    = weird.substring(0, weirdIndex) + ' ' + weird.substring(weirdIndex, weird.length);
+
+            items[x] = weird.split(" ").filter(this.removeBlanks);
+          }
+
+          if (items[x][4].search(this.remoteMonths) != -1 && !parseInt(items[x][3].charAt(0))) {
+            var weird = temp;                                                      // added to support 'weird 2' servers, oy vey
+
+            if (weird.charAt(10) != ' ') {                                         // same as above code
+              weird = weird.substring(0, 10) + ' ' + weird.substring(10, weird.length);
+            }
+
+            var weirdIndex = 0;
+
+            for (var y = 0; y < items[x][3].length; ++y) {
+              if (parseInt(items[x][3].charAt(y))) {
+                weirdIndex = weird.indexOf(items[x][3]) + y;
+                break;
+              }
+            }
+
+            weird    = weird.substring(0, weirdIndex) + ' ' + weird.substring(weirdIndex, weird.length);
+
+            items[x] = weird.split(" ").filter(this.removeBlanks);
+          }
+
+          if (items[x][4].search(this.remoteMonths) != -1) {                       // added to support novell servers
+            offset   = 1;
+          }
+
+          var index = 0;
+          for (var y = 0; y < 7 - offset; ++y) {
+            index = temp.indexOf(items[x][y], index) + items[x][y].length + 1;
+          }
+
+          var name    = temp.substring(temp.indexOf(items[x][7 - offset], index) + items[x][7 - offset].length + 1, temp.length);
+          name        = name.substring(name.search(/[^\s]/));
+          var symlink = "";
+
+          if (items[x][0].charAt(0) == 'l') {
+            symlink = name;
+
+            name    = name.substring(0, name.indexOf("->") - 1);
+            symlink = symlink.substring(symlink.indexOf("->") + 3);
+          }
+
+          name             = (name.lastIndexOf('/') == -1 ? name : name.substring(name.lastIndexOf('/') + 1));
+          var remotepath   = this.constructPath(path, name);
+          var month;
+
+          var rawDate    = items[x][6 - offset];
+
+          if (items[x][6].search(this.remoteMonths) != -1) {                       // added to support aix servers
+            month        = this.remoteMonths.search(items[x][6 - offset]) / 4;
+            rawDate      = items[x][5 - offset];
+          } else {
+            month        = this.remoteMonths.search(items[x][5 - offset]) / 4;
+          }
+
+          var timeOrYear;
+          var curDate    = new Date();
+          var currentYr  = curDate.getMonth() < month ? curDate.getFullYear() - 1 : curDate.getFullYear();
+          var rawYear    = items[x][7 - offset].indexOf(':') != -1 ? currentYr            : parseInt(items[x][7 - offset]);
+          var rawTime    = items[x][7 - offset].indexOf(':') != -1 ? items[x][7 - offset] : "00:00";
+
+          rawTime        = rawTime.split(":");
+
+          for (var y = 0; y < rawTime.length; ++y) {
+            rawTime[y]   = parseInt(rawTime[y], 10);
+          }
+
+          var parsedDate = new Date(rawYear, month, rawDate, rawTime[0], rawTime[1]);  // month-day-year format
+          parsedDate.setMinutes(parsedDate.getMinutes() + this.timezone);
+
+          if (new Date() - parsedDate > 15600000000) {                             // roughly 6 months
+            timeOrYear   = parsedDate.getFullYear();
+          } else {
+            timeOrYear   = this.zeroPadTime(parsedDate.getHours()) + ":" + this.zeroPadTime(parsedDate.getMinutes());
+          }
+
+          month          = this.l10nMonths[parsedDate.getMonth()];
+          items[x]       = { permissions : items[x][0],
+                             hardLink    : items[x][1],
+                             user        : items[x][2],
+                             group       : (offset ? "" : items[x][3]),
+                             fileSize    : items[x][4 - offset],
+                             date        : month + ' ' + parsedDate.getDate() + ' ' + timeOrYear,
+                             leafName    : name,
+                             isDir       : items[x][0].charAt(0) == 'd',
+                             isDirectory : function() { return this.isDir },
+                             isSymlink   : function() { return this.symlink != "" },
+                             symlink     : symlink,
+                             path        : remotepath };
+
+        } else if (items[x][0].indexOf('-') == -1) {                               // os/2 style
+          var offset = 0;
+
+          if (items[x][2].indexOf(':') != -1) {                                    // if "DIR" and "A" are missing
+            offset   = 1;
+          }
+
+          var rawDate    = items[x][2 - offset].split("-");
+          var rawTime    = items[x][3 - offset];
+          var timeOrYear = rawTime;
+          rawTime        = rawTime.split(":");
+
+          for (var y = 0; y < rawDate.length; ++y) {
+            rawDate[y]   = parseInt(rawDate[y], 10);                               // leading zeros are treated as octal so pass 10 as base argument
+          }
+
+          for (var y = 0; y < rawTime.length; ++y) {
+            rawTime[y]   = parseInt(rawTime[y], 10);
+          }
+
+          rawDate[2]     = rawDate[2] + 1900;                                      // ah, that's better
+          var parsedDate = new Date(rawDate[2], rawDate[0] - 1, rawDate[1], rawTime[0], rawTime[1]);  // month-day-year format
+          parsedDate.setMinutes(parsedDate.getMinutes() + this.timezone);
+
+          if (new Date() - parsedDate > 15600000000) {                             // roughly 6 months
+            timeOrYear   = parsedDate.getFullYear();
+          } else {
+            timeOrYear   = this.zeroPadTime(parsedDate.getHours()) + ":" + this.zeroPadTime(parsedDate.getMinutes());
+          }
+
+          var month      = this.l10nMonths[parsedDate.getMonth()];
+          var name       = temp.substring(temp.indexOf(items[x][3 - offset]) + items[x][3 - offset].length + 1, temp.length);
+          name           = name.substring(name.search(/[^\s]/));
+          name           = (name.lastIndexOf('/') == -1 ? name : name.substring(name.lastIndexOf('/') + 1));
+          items[x]       = { permissions : items[x][1] == "DIR" ? "d---------" : "----------",
+                             hardLink    : "",
+                             user        : "",
+                             group       : "",
+                             fileSize    : items[x][0],
+                             date        : month + ' ' + parsedDate.getDate() + ' ' + timeOrYear,
+                             leafName    : name,
+                             isDir       : items[x][1] == "DIR",
+                             isDirectory : function() { return this.isDir },
+                             isSymlink   : function() { return this.symlink != "" },
+                             symlink     : "",
+                             path        : this.constructPath(path, name) };
+
+        } else {                                                                   // ms-dos style
+          var rawDate    = items[x][0].split("-");
+          var amPm       = items[x][1].substring(5, 7);                            // grab PM or AM
+          var rawTime    = items[x][1].substring(0, 5);                            // get rid of PM, AM
+          var timeOrYear = rawTime;
+          rawTime        = rawTime.split(":");
+
+          for (var y = 0; y < rawDate.length; ++y) {
+            rawDate[y]   = parseInt(rawDate[y], 10);
+          }
+
+          for (var y = 0; y < rawTime.length; ++y) {
+            rawTime[y]   = parseInt(rawTime[y], 10);
+          }
+
+          rawTime[0] = rawTime[0] == 12 && amPm == "AM" ? 0 : (rawTime[0] < 12 && amPm == "PM" ? rawTime[0] + 12 : rawTime[0]);
+
+          if (rawDate[2] < 70) {                                                   // assuming you didn't have some files left over from 1904
+            rawDate[2]   = rawDate[2] + 2000;                                      // ah, that's better
+          } else {
+            rawDate[2]   = rawDate[2] + 1900;
+          }
+
+          var parsedDate = new Date(rawDate[2], rawDate[0] - 1, rawDate[1], rawTime[0], rawTime[1]);  // month-day-year format
+          parsedDate.setMinutes(parsedDate.getMinutes() + this.timezone);
+
+          if (new Date() - parsedDate > 15600000000) {                             // roughly 6 months
+            timeOrYear   = parsedDate.getFullYear();
+          } else {
+            timeOrYear   = this.zeroPadTime(parsedDate.getHours()) + ":" + this.zeroPadTime(parsedDate.getMinutes());
+          }
+
+          var month      = this.l10nMonths[parsedDate.getMonth()];
+          var name       = temp.substring(temp.indexOf(items[x][2], temp.indexOf(items[x][1]) + items[x][1].length + 1)
+                           + items[x][2].length + 1, temp.length);
+          name           = name.substring(name.search(/[^\s]/));
+          name           = (name.lastIndexOf('/') == -1 ? name : name.substring(name.lastIndexOf('/') + 1));
+          items[x]       = { permissions : items[x][2] == "<DIR>" ? "d---------" : "----------",
+                             hardLink    : "",
+                             user        : "",
+                             group       : "",
+                             fileSize    : items[x][2] == "<DIR>" ? '0' : items[x][2],
+                             date        : month + ' ' + parsedDate.getDate() + ' ' + timeOrYear,
+                             leafName    : name,
+                             isDir       : items[x][2] == "<DIR>",
+                             isDirectory : function() { return this.isDir },
+                             isSymlink   : function() { return this.symlink != "" },
+                             symlink     : "",
+                             path        : this.constructPath(path, name) };
+        }
+
+        if (!items[x].lastModifiedTime) {
+          var dateTemp  = items[x].date;                                             // this helps with sorting by date
+          var dateMonth = dateTemp.substring(0, 3);
+          var dateIndex = this.l10nMonths.indexOf(dateMonth);
+          dateTemp      = this.remoteMonths.substr(dateIndex * 4, 3) + dateTemp.substring(3);
+
+          if (items[x].date.indexOf(':') != -1) {
+            dateTemp = dateTemp + ' ' + (curDate.getFullYear() - (curDate.getMonth() < dateIndex ? 1 : 0));
+          }
+
+          items[x].lastModifiedTime = Date.parse(dateTemp);
+        }
+
+        items[x].fileSize = parseInt(items[x].fileSize);
+
+        items[x].parent = { path: items[x].path.substring(0, items[x].path.lastIndexOf('/') ? items[x].path.lastIndexOf('/') : 1) };
+      } catch (ex) {
+        this.observer.onError(ex + items[x].toSource());
+        items.splice(x, 1);
+        --x;
+      }
+    }
+
+    var directories = new Array();                                               // sort directories to the top
+    var files       = new Array();
+
+    for (var x = 0; x < items.length; ++x) {
+      if (!this.hiddenMode && items[x].leafName.charAt(0) == ".") {              // don't show hidden files
+        continue;
+      }
+
+      items[x].isHidden = items[x].leafName.charAt(0) == ".";
+
+      items[x].leafName = items[x].leafName.replace(/[\\\/]/g, '');              // scrub out / or \, a security vulnerability if file tries to do ..\..\blah.txt
+      items[x].path     = this.constructPath(path, items[x].leafName);           // thanks to Tan Chew Keong for the heads-up
+
+      if (items[x].leafName == "." || items[x].leafName == "..") {               // get rid of "." or "..", this can screw up things on recursive deletions
+        continue;
+      }
+
+      if (items[x].isDirectory()) {
+        directories.push(items[x]);
+      } else {
+        files.push(items[x]);
+      }
+    }
+
+    items = directories.concat(files);
+
+    if (this.sessionsMode) {
+      try {                                                                      // put in cache
+        var cacheSession = this.cacheService.createSession("fireftp", 1, true);
+        cacheSession.asyncOpenCacheEntry(this.protocol + "://" + this.version + this.connectedHost + path,
+            Components.interfaces.nsICache.ACCESS_WRITE,
+            {
+              onCacheEntryAvailable : function(cacheDesc, accessGranted, status) {
+                try {
+                  if (cacheDesc) {
+                    var cacheOut     = cacheDesc.openOutputStream(0);
+                    var cacheData    = unescape(encodeURIComponent(JSON.stringify(items)));
+                    cacheOut.write(cacheData, cacheData.length);
+                    cacheOut.close();
+                    cacheDesc.close();
+                  }
+                } catch (ex) {}
+              }
+            });
+      } catch (ex) {
+        this.observer.onDebug(ex);
+      }
+    }
+
+    return items;
+  },
+
+  cacheHit : function(path, callback) {
+    try {                                                                        // check the cache first
+      var cacheSession   = this.cacheService.createSession("fireftp", 1, true);
+      var self = this;
+      cacheSession.asyncOpenCacheEntry(this.protocol + "://" + this.version + this.connectedHost + path,
+          Components.interfaces.nsICache.ACCESS_READ,
+          {
+            onCacheEntryAvailable : function(cacheDesc, accessGranted, status) {
+              if (!cacheDesc) {
+                callback(false);
+                return;
+              }
+
+              try {
+                if (cacheDesc.predictedDataSize) {
+                  var cacheIn       = cacheDesc.openInputStream(0);
+                  var cacheInstream = Components.classes["@mozilla.org/binaryinputstream;1"].createInstance(Components.interfaces.nsIBinaryInputStream);
+                  cacheInstream.setInputStream(cacheIn);
+                  self.listData     = cacheInstream.readBytes(cacheInstream.available());
+                  self.listData     = JSON.parse(decodeURIComponent(escape(self.listData)));
+                  for (var x = 0; x < self.listData.length; ++x) {                         // these functions get lost when encoding in JSON
+                    self.listData[x].isDirectory = function() { return this.isDir };
+                    self.listData[x].isSymlink   = function() { return this.symlink != "" };
+                  }
+                  cacheInstream.close();
+                  cacheDesc.close();
+
+                  self.observer.onDebug(self.listData.toSource().replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/, {/g, ',\n{')
+                               .replace(/, isDirectory:\(function \(\) { return this.isDir }\), isSymlink:\(function \(\) { return this.symlink != "" }\)/g, ''),
+                                                       "DEBUG-CACHE");
+                }
+
+                callback(true);
+              } catch(ex) {
+                callback(false);
+              }
+            }
+          });
+    } catch (ex) {
+      callback(false);
+    }
+  },
+
+  removeCacheEntry : function(path) {
+    try {
+      var cacheSession = this.cacheService.createSession("fireftp", 1, true);
+      cacheSession.asyncOpenCacheEntry(this.protocol + "://" + this.version + this.connectedHost + path,
+          Components.interfaces.nsICache.ACCESS_WRITE,
+          {
+            onCacheEntryAvailable : function(cacheDesc, accessGranted, status) {
+              if (cacheDesc) {
+                cacheDesc.doom();
+                cacheDesc.close();
+              }
+            }
+          });
+    } catch (ex) {
+      this.observer.onDebug(ex);
+    }
+  },
+
+  constructPath : function(parent, leafName) {
+    return parent + (parent.charAt(parent.length - 1) != '/' ? '/' : '') + leafName;
+  },
+
+  removeBlanks : function(element, index, array) {
+    return element;
+  },
+
+  zeroPad : function(str) {
+    return str.length == 3 ? str : (str.length == 2 ? '0' + str : '00' + str);
+  },
+
+  zeroPadTime : function(num) {
+    num = num.toString();
+    return num.length == 2 ? num : '0' + num;
+  },
+
+  setCharAt : function(str, index, ch) {                                         // how annoying
+    return str.substr(0, index) + ch + str.substr(index + 1);
+  },
+
+  setEncoding : function(encoding) {
+    try {
+      this.fromUTF8.charset = encoding;
+      this.encoding         = encoding;
+    } catch (ex) {
+      this.fromUTF8.charset = "UTF-8";
+      this.encoding         = "UTF-8";
+    }
+  },
+
+  binaryToHex : function(input) {                                                // borrowed from nsUpdateService.js
+    var result = "";
+
+    for (var i = 0; i < input.length; ++i) {
+      var hex = input.charCodeAt(i).toString(16);
+
+      if (hex.length == 1) {
+        hex = "0" + hex;
+      }
+
+      result += hex;
+    }
+
+    return result;
+  }
+};
+
+function setProtocol(protocol) {
+  var protocolMap = { 'ftp'  : { 'transport': ftpMozilla,  'observer': ftpObserver },
+                      'ssh2' : { 'transport': ssh2Mozilla, 'observer': ssh2Observer } };
+
+  gConnections = new Array();
+  for (var x = 0; x < gMaxCon; ++x) {
+    gConnections.push(new protocolMap[protocol].transport(x ? new transferObserver(x + 1) : new protocolMap[protocol].observer()));
+    gConnections[x].type            = x ? 'transfer' : '';
+    gConnections[x].connNo          = x + 1;
+    gConnections[x].errorConnectStr = gStrbundle.getString("errorConn");
+    gConnections[x].errorXCheckFail = gStrbundle.getString("errorXCheckFail");
+    gConnections[x].passNotShown    = gStrbundle.getString("passNotShown");
+    gConnections[x].l10nMonths      = gStrbundle.getString("months").split("|");
+    gConnections[x].version         = gVersion;
+  }
+
+  gConnection = gConnections[0];
+
+  readPreferences();
+}

--- a/src/content/js/connection/baseProtocol.js
+++ b/src/content/js/connection/baseProtocol.js
@@ -1,6 +1,13 @@
 // if you're actually interested in reusing this class for your app
 // it'd be a good idea to get in contact with me, Mime Cuvalo: mimecuvalo@gmail.com
 
+let {LoadContextInfo} = Components.utils.import(
+  "resource://gre/modules/LoadContextInfo.jsm", {}
+);
+let {PrivateBrowsingUtils} = Components.utils.import(
+  "resource://gre/modules/PrivateBrowsingUtils.jsm", {}
+);
+
 function baseProtocol() {
   this.eventQueue = [];             // commands to be sent
   this.trashQueue = [];             // once commands are read, throw them away here b/c we might have to recycle these if there is an error
@@ -41,7 +48,7 @@ baseProtocol.prototype = {
   // read-only variables
   transportService     : Components.classes["@mozilla.org/network/socket-transport-service;1"].getService(Components.interfaces.nsISocketTransportService),
   proxyService         : Components.classes["@mozilla.org/network/protocol-proxy-service;1"].getService  (Components.interfaces.nsIProtocolProxyService),
-  cacheService         : Components.classes["@mozilla.org/network/cache-service;1"].getService           (Components.interfaces.nsICacheService),
+  cacheService         : Components.classes["@mozilla.org/netwerk/cache-storage-service;1"].getService   (Components.interfaces.nsICacheStorageService),
   toUTF8               : Components.classes["@mozilla.org/intl/utf8converterservice;1"].getService       (Components.interfaces.nsIUTF8ConverterService),
   fromUTF8             : Components.classes["@mozilla.org/intl/scriptableunicodeconverter"].getService   (Components.interfaces.nsIScriptableUnicodeConverter),
   isAttemptingConnect  : false,
@@ -57,8 +64,8 @@ baseProtocol.prototype = {
   controlTransport     : null,
   controlInstream      : null,
   controlOutstream     : null,
-  dataSocket           : null,           // only used with (*ahem* lame *ahem*) protocols like FTP that need a second socket 
-  
+  dataSocket           : null,           // only used with (*ahem* lame *ahem*) protocols like FTP that need a second socket
+
   doingCmdBatch        : false,
 
   connectedHost        : "",             // name of the host we connect to plus username
@@ -1020,22 +1027,29 @@ baseProtocol.prototype = {
 
     if (this.sessionsMode) {
       try {                                                                      // put in cache
-        var cacheSession = this.cacheService.createSession("fireftp", 1, true);
-        cacheSession.asyncOpenCacheEntry(this.protocol + "://" + this.version + this.connectedHost + path,
-            Components.interfaces.nsICache.ACCESS_WRITE,
-            {
-              onCacheEntryAvailable : function(cacheDesc, accessGranted, status) {
-                try {
-                  if (cacheDesc) {
-                    var cacheOut     = cacheDesc.openOutputStream(0);
-                    var cacheData    = unescape(encodeURIComponent(JSON.stringify(items)));
-                    cacheOut.write(cacheData, cacheData.length);
-                    cacheOut.close();
-                    cacheDesc.close();
-                  }
-                } catch (ex) {}
-              }
-            });
+        var storage = this.cacheService.memoryCacheStorage(
+          // Note: make sure |window| is the window you want
+          LoadContextInfo.fromLoadContext(PrivateBrowsingUtils.privacyContextFromWindow(window, false)), false
+        );
+        storage.asyncOpenURI(
+          this.makeURI(this.protocol + "://" + this.version + this.connectedHost + path),
+          "",
+          Components.interfaces.nsICacheStorage.OPEN_TRUNCATE,
+          {
+            onCacheEntryCheck: function (entry, appcache) {
+              return Components.interfaces.nsICacheEntryOpenCallback.ENTRY_WANTED;
+            },
+            onCacheEntryAvailable: function (cacheDesc, isnew, appcache, status) {
+              try {
+                if (cacheDesc) {
+                  var cacheOut     = cacheDesc.openOutputStream(0);
+                  var cacheData    = unescape(encodeURIComponent(JSON.stringify(items)));
+                  cacheOut.write(cacheData, cacheData.length);
+                  cacheOut.close();
+                }
+              } catch (ex) {}
+            }
+          });
       } catch (ex) {
         this.observer.onDebug(ex);
       }
@@ -1046,42 +1060,49 @@ baseProtocol.prototype = {
 
   cacheHit : function(path, callback) {
     try {                                                                        // check the cache first
-      var cacheSession   = this.cacheService.createSession("fireftp", 1, true);
+      var storage = this.cacheService.memoryCacheStorage(
+        // Note: make sure |window| is the window you want
+        LoadContextInfo.fromLoadContext(PrivateBrowsingUtils.privacyContextFromWindow(window, false)), false
+      );
       var self = this;
-      cacheSession.asyncOpenCacheEntry(this.protocol + "://" + this.version + this.connectedHost + path,
-          Components.interfaces.nsICache.ACCESS_READ,
-          {
-            onCacheEntryAvailable : function(cacheDesc, accessGranted, status) {
-              if (!cacheDesc) {
-                callback(false);
-                return;
-              }
-
-              try {
-                if (cacheDesc.predictedDataSize) {
-                  var cacheIn       = cacheDesc.openInputStream(0);
-                  var cacheInstream = Components.classes["@mozilla.org/binaryinputstream;1"].createInstance(Components.interfaces.nsIBinaryInputStream);
-                  cacheInstream.setInputStream(cacheIn);
-                  self.listData     = cacheInstream.readBytes(cacheInstream.available());
-                  self.listData     = JSON.parse(decodeURIComponent(escape(self.listData)));
-                  for (var x = 0; x < self.listData.length; ++x) {                         // these functions get lost when encoding in JSON
-                    self.listData[x].isDirectory = function() { return this.isDir };
-                    self.listData[x].isSymlink   = function() { return this.symlink != "" };
-                  }
-                  cacheInstream.close();
-                  cacheDesc.close();
-
-                  self.observer.onDebug(self.listData.toSource().replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/, {/g, ',\n{')
-                               .replace(/, isDirectory:\(function \(\) { return this.isDir }\), isSymlink:\(function \(\) { return this.symlink != "" }\)/g, ''),
-                                                       "DEBUG-CACHE");
-                }
-
-                callback(true);
-              } catch(ex) {
-                callback(false);
-              }
+      storage.asyncOpenURI(
+        this.makeURI(this.protocol + "://" + this.version + this.connectedHost + path),
+        "",
+        Components.interfaces.nsICacheStorage.OPEN_PRIORITY,
+        {
+          onCacheEntryCheck: function (entry, appcache) {
+            return Components.interfaces.nsICacheEntryOpenCallback.ENTRY_WANTED;
+          },
+          onCacheEntryAvailable: function (cacheDesc, isNew, appcache, status) {
+            if (isNew) {
+              callback(false);
+              return;
             }
-          });
+
+            try {
+              var cacheIn       = cacheDesc.openInputStream(0);
+              var cacheInstream = Components.classes["@mozilla.org/binaryinputstream;1"].createInstance(Components.interfaces.nsIBinaryInputStream);
+              cacheInstream.setInputStream(cacheIn);
+
+              self.listData     = cacheInstream.readBytes(cacheInstream.available());
+              self.listData     = JSON.parse(decodeURIComponent(escape(self.listData)));
+              for (var x = 0; x < self.listData.length; ++x) {                         // these functions get lost when encoding in JSON
+                self.listData[x].isDirectory = function() { return this.isDir };
+                self.listData[x].isSymlink   = function() { return this.symlink != "" };
+              }
+              cacheInstream.close();
+
+              self.observer.onDebug(self.listData.toSource().replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/, {/g, ',\n{')
+                           .replace(/, isDirectory:\(function \(\) { return this.isDir }\), isSymlink:\(function \(\) { return this.symlink != "" }\)/g, ''),
+                                                   "DEBUG-CACHE");
+
+              callback(true);
+            } catch(ex) {
+              callback(false);
+            }
+          }
+        }
+      );
     } catch (ex) {
       callback(false);
     }
@@ -1089,17 +1110,24 @@ baseProtocol.prototype = {
 
   removeCacheEntry : function(path) {
     try {
-      var cacheSession = this.cacheService.createSession("fireftp", 1, true);
-      cacheSession.asyncOpenCacheEntry(this.protocol + "://" + this.version + this.connectedHost + path,
-          Components.interfaces.nsICache.ACCESS_WRITE,
-          {
-            onCacheEntryAvailable : function(cacheDesc, accessGranted, status) {
-              if (cacheDesc) {
-                cacheDesc.doom();
-                cacheDesc.close();
-              }
+      var storage = this.cacheService.memoryCacheStorage(
+        // Note: make sure |window| is the window you want
+        LoadContextInfo.fromLoadContext(PrivateBrowsingUtils.privacyContextFromWindow(window, false)), false
+      );
+      storage.asyncOpenURI(
+        this.makeURI(this.protocol + "://" + this.version + this.connectedHost + path),
+        "",
+        Components.interfaces.nsICacheStorage.OPEN_PRIORITY,
+        {
+          onCacheEntryCheck: function (entry, appcache) {
+            return Components.interfaces.nsICacheEntryOpenCallback.ENTRY_WANTED;
+          },
+          onCacheEntryAvailable: function (cacheDesc, isnew, appcache, status) {
+            if (cacheDesc) {
+              cacheDesc.asyncDoom(null);
             }
-          });
+          }
+        });
     } catch (ex) {
       this.observer.onDebug(ex);
     }
@@ -1150,6 +1178,11 @@ baseProtocol.prototype = {
     }
 
     return result;
+  },
+  makeURI : function(aURL, aOriginCharset, aBaseURI) {
+    var ioService = Components.classes["@mozilla.org/network/io-service;1"]
+                    .getService(Components.interfaces.nsIIOService);
+    return ioService.newURI(aURL, aOriginCharset, aBaseURI);
   }
 };
 

--- a/src/content/js/etc/fireftpOverlay-pm.js
+++ b/src/content/js/etc/fireftpOverlay-pm.js
@@ -1,0 +1,171 @@
+/* ideas for this bit of gpl'ed code came from ieview (http://ieview.mozdev.org)
+ * and that team is... Paul Roub, Ted Mielczarek, and Fabricio Campos Zuardi
+ * thanks to Scott Bentley for the suggestion
+ */
+
+function loadFireFTP() {
+  var prefService    = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+  var prefSvc        = prefService.getBranch(null);
+
+  var loadMode = 0;
+  try {
+    loadMode = prefSvc.getIntPref("fireftp.loadmode");
+  } catch (ex) {
+    loadMode = 1;
+  }
+
+  if (loadMode == 1) {
+    var theTab          = gBrowser.addTab('chrome://fireftp/content/fireftp-pm.xul');
+    theTab.label        = "FireFTP";
+    gBrowser.selectedTab = theTab;
+  } else if (loadMode == 2) {
+    toOpenWindowByType('mozilla:fireftp', 'chrome://fireftp/content/fireftp-pm.xul');
+  } else {
+    var ww = Components.classes["@mozilla.org/embedcomp/window-watcher;1"].getService(Components.interfaces.nsIWindowWatcher);
+    var win = ww.getWindowByName("FireFTP", null);
+    if (win) {
+      var theTab          = win.gBrowser.addTab('chrome://fireftp/content/fireftp-pm.xul');
+      theTab.label        = "FireFTP";
+      win.gBrowser.selectedTab = theTab;
+      win.focus();
+    } else {
+      var sa = Components.classes["@mozilla.org/supports-array;1"].createInstance(Components.interfaces.nsISupportsArray);
+      var wuri = Components.classes["@mozilla.org/supports-string;1"].createInstance(Components.interfaces.nsISupportsString);
+      wuri.data = "chrome://fireftp/content/fireftp-pm.xul";
+      sa.AppendElement(wuri);
+      var win = ww.openWindow(null, getBrowserURL(), "FireFTP", null, sa);
+    }
+  }
+}
+
+function loadFireFTPFromContentArea() {
+  loadFireFTPHelper(gBrowser.currentURI.spec);
+}
+
+function loadFireFTPFromContext() {
+  loadFireFTPHelper(gContextMenu.getLinkURL());
+}
+
+function loadFireFTPFromLink(event) {
+  var link = event.originalTarget;
+
+  if (!link || !link.href) {
+    link = event.currentTarget;
+  }
+
+  if (!link || !link.href) {
+    return true;
+  }
+
+  event.preventDefault();
+  loadFireFTPHelper(link.href);
+  return false;
+}
+
+function loadFireFTPHelper(uri) {
+  if (uri.toLowerCase().indexOf("ftp://") != 0) {
+    return;
+  }
+
+  var prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+  var prefBranch  = prefService.getBranch("fireftp.");
+  var sString  = Components.classes["@mozilla.org/supports-string;1"].createInstance(Components.interfaces.nsISupportsString);
+  sString.data = uri;
+  prefBranch.setComplexValue("loadurl", Components.interfaces.nsISupportsString, sString);
+  loadFireFTP();
+}
+
+function fireFTPInitListener(event) {
+  var menu       = document.getElementById("contentAreaContextMenu");
+  var appcontent = document.getElementById("appcontent");   // browser
+
+  var prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+  var prefBranch  = prefService.getBranch("fireftp.");
+  var donated     = prefBranch.getBoolPref("donated");
+
+  // If 'Web Developer' menu is available (introduced in Firefox 6)
+  // Remove the old entry in Tools menu.
+  if (document.getElementById("menu_webDeveloper_fireftp")) {
+    var menuFireftp = document.getElementById("fireftptoolsmenu");
+    if (menuFireftp) {
+      menuFireftp.parentNode.removeChild(menuFireftp);
+    }
+  }
+
+  if (menu) {
+    menu.addEventListener("popupshowing", fireFTPContextListener, false);
+  }
+
+  if (appcontent) {
+    appcontent.addEventListener("load", fireFTPLoadListener, true);
+  }
+
+  if (!donated) {
+    prefBranch.setBoolPref("donated", true);
+
+    var windowContent = window.getBrowser();
+    window.setTimeout(function() {
+      windowContent.selectedTab = windowContent.addTab("http://fireftp.net/donate.html?installed=true");
+    }, 0);
+  }
+}
+
+function fireFTPCheckForcedListener(event) {
+  var doc               = event.originalTarget;
+  var prefService       = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+  var prefBranch        = prefService.getBranch("fireftp.");
+  var integrateftplinks = prefBranch.getBoolPref("integrateftplinks");
+
+  var framed = event.originalTarget && window._content && window._content.document && (window._content.document != event.originalTarget);
+
+  if (!integrateftplinks || framed) {
+    return;
+  }
+
+  if (doc.location && doc.location.href && doc.location.href.toLowerCase().indexOf("ftp://") == 0) {
+    var ws = gBrowser.docShell.QueryInterface(Components.interfaces.nsIRefreshURI);
+
+    if (ws) {
+      ws.cancelRefreshURITimers();
+    }
+
+    var sString  = Components.classes["@mozilla.org/supports-string;1"].createInstance(Components.interfaces.nsISupportsString);
+    sString.data = window._content.document.documentURI;
+    prefBranch.setComplexValue("loadurl", Components.interfaces.nsISupportsString, sString);
+
+    doc.location.href = "chrome://fireftp/content/fireftp-pm.xul";
+  }
+}
+
+function fireFTPContextListener(event) {
+  if (!gContextMenu) {
+    return;
+  }
+
+  var uri = gContextMenu.onLink ? gContextMenu.getLinkURL() : gBrowser.currentURI.spec;
+
+  document.getElementById("fireftpcontentarea").hidden =  gContextMenu.onLink || uri.toLowerCase().indexOf("ftp://") != 0;
+  document.getElementById("fireftpcontextmenu").hidden = !gContextMenu.onLink || uri.toLowerCase().indexOf("ftp://") != 0;
+}
+
+function fireFTPLoadListener(event) {
+  var doc               = event.originalTarget;
+  var prefService       = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+  var prefBranch        = prefService.getBranch("fireftp.");
+  var integrateftplinks = prefBranch.getBoolPref("integrateftplinks");
+
+  if (!integrateftplinks || !doc || !doc.getElementsByTagName) {
+    return;
+  }
+
+  var links = doc.getElementsByTagName('a');
+
+  for (var x = 0; x < links.length; ++x) {
+    if (links[x] && links[x].href && links[x].href.toLowerCase().indexOf("ftp://") == 0) {
+      links[x].addEventListener('click', loadFireFTPFromLink, true);
+    }
+  }
+}
+
+window.addEventListener("load",             fireFTPInitListener,        false);
+window.addEventListener("DOMContentLoaded", fireFTPCheckForcedListener, false);

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -22,6 +22,14 @@
         <em:maxVersion>32.*</em:maxVersion>
       </Description>
     </em:targetApplication>
+    <!-- Pale Moon -->
+    <em:targetApplication>
+      <Description>
+        <em:id>{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}</em:id>
+        <em:minVersion>25.0</em:minVersion>
+        <em:maxVersion>29.*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
     <!-- SeaMonkey -->
     <em:targetApplication>
       <Description>

--- a/src/install.rdf.in
+++ b/src/install.rdf.in
@@ -22,6 +22,14 @@
         <em:maxVersion>__MAXVERSION__</em:maxVersion>
       </Description>
     </em:targetApplication>
+    <!-- Pale Moon -->
+    <em:targetApplication>
+      <Description>
+        <em:id>{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}</em:id>
+        <em:minVersion>25.0</em:minVersion>
+        <em:maxVersion>29.*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
     <!-- SeaMonkey -->
     <em:targetApplication>
       <Description>


### PR DESCRIPTION
This PR will add compatibility of FireFTP with Pale Moon 25.0+
Since Pale Moon uses the pre-FF32 API that was switched away from in FireFTP 2.0.21, I had to split the code paths, restoring the previous state for Pale Moon in its own XUL/js modules.

I've tested the result on both Pale Moon 25.0.1 and FF33.0, and both seem to be happy with this.
