### PR TITLE
fixes #172: pass already-received sslStatus to exceptionDialog.xul

### DIFF
--- a/src/content/js/connection/baseObserver.js
+++ b/src/content/js/connection/baseObserver.js
@@ -319,7 +319,7 @@ var securityCallbacks = {
         return;
       }
 
-      var params = { location : targetSite, exceptionAdded : false };
+      var params = { location : targetSite, exceptionAdded : false, sslStatus : status };
       window.openDialog('chrome://pippki/content/exceptionDialog.xul', '', 'chrome,centerscreen,modal', params);
 
       if (params.exceptionAdded) {


### PR DESCRIPTION
This should address #172 by passing the (already received) sslStatus to exceptionDialog.xul, which can then use it directly instead of attempting to fetch it again (I think the issue is basically that exceptionDialog tries to make an XHR to the given host:port, but if the server isn't speaking http(s), that generally doesn't work well).