### PR TITLE
Improve icon sizing

### DIFF
--- a/src/skin/overlay.css
+++ b/src/skin/overlay.css
@@ -1,3 +1,12 @@
-#fireftp-button, #fireftp-button2, #fireftptoolsmenu, #fireftpcontentarea, #fireftpcontextmenu, #appmenu_fireftp, #menu_webDeveloper_fireftp {
+toolbar[iconsize="small"] #fireftp-button,
+#fireftptoolsmenu, #fireftpcontentarea, #fireftpcontextmenu, #appmenu_fireftp, #menu_webDeveloper_fireftp {
+  list-style-image    : url("chrome://fireftp/skin/icons/logo.png");
+}
+
+#fireftp-button {
   list-style-image    : url("chrome://fireftp/skin/icons/logo32.png");
+}
+
+toolbar[iconsize="large"] #fireftp-button {
+  list-style-image    : url("chrome://fireftp/skin/icons/logo24.png");
 }


### PR DESCRIPTION
This fixes the icon sizes so that they look correct everywhere (this was particularly an issue on Pale Moon, where they looked out of place with the other icons). As an example, see below on Pale Moon, before and after:

Before:

![Before](http://i.imgur.com/euQtsZb.png)

After:

![After](http://i.imgur.com/ajXXWjB.png)

This also improves the consistency of the icon on Firefox too. Please see below:

Toolbar:

![Toolbar](http://i.imgur.com/Om1lll5.png)

Customize panel/hamburger menu:

![Customize](http://i.imgur.com/xCebd6S.png)

Thanks!